### PR TITLE
Remove dns64 plugin from connectivity-dns controller

### DIFF
--- a/cmd/connectivity-dns/main.go
+++ b/cmd/connectivity-dns/main.go
@@ -18,7 +18,6 @@ import (
 	_ "github.com/coredns/coredns/plugin/cancel"
 	_ "github.com/coredns/coredns/plugin/chaos"
 	_ "github.com/coredns/coredns/plugin/debug"
-	_ "github.com/coredns/coredns/plugin/dns64"
 	_ "github.com/coredns/coredns/plugin/dnssec"
 	_ "github.com/coredns/coredns/plugin/dnstap"
 	_ "github.com/coredns/coredns/plugin/erratic"
@@ -67,7 +66,6 @@ var directives = []string{
 	"errors",
 	"log",
 	"dnstap",
-	"dns64",
 	"acl",
 	"any",
 	"chaos",


### PR DESCRIPTION
Running `make build-images` fails with the following error:

```bash
pkg/coredns/plugins/crosscluster/setup.go:22:18: cannot use setup (type func(*"github.com/caddyserver/caddy".Controller) error) as type "github.com/coredns/caddy".SetupFunc in argument to plugin.Register
pkg/coredns/plugins/crosscluster/setup.go:33:21: cannot use c (type *"github.com/caddyserver/caddy".Controller) as type *"github.com/coredns/caddy".Controller in argument to dnsserver.GetConfig
```

After some sluething, `make build-images` is bumping the `github.com/coredns/coredns` library from `v1.6.9` to `v1.8.0` and the method signature appears to have slightly changed in that bump. Actually, bumping to `v1.8.0` will take some effort to do properly, because it bumps other libraries and there will be some dependency management to work out. So this PR is to ensure it can build with `v1.6.9`.

Go is trying to bump to `v1.8.0` because we are importing the `github.com/coredns/coredns/plugin/dns64` package, which was introduced in `v1.7.0` and does not exist in `1.6.9`. This PR removes that plugin and package so it can be built with CoreDNS `v1.6.9`.