### PR TITLE
Add .sh and Dockerfile to addlicense/checklicense

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ make test-connectivity
 
 If you are introducing any new source files, then you must add the
 [license](https://github.com/vmware-tanzu/cross-cluster-connectivity/blob/main/hack/license.txt)
-to the top of every file. This can be done automatically for `.go` files using:
+to the top of every file. This can be done automatically using:
 
 ```
 make addlicense

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,13 @@ $(CONTROLLER_GEN): # Build controller-gen from tools folder.
 .PHONY: addlicense
 addlicense:
 	# requires https://github.com/google/addlicense
-	# Only checks .go files at the moment
-	addlicense -f ./hack/license.txt $(shell find . -name *.go)
+	addlicense -f ./hack/license.txt $(shell find . -path ./hack/tools/vendor -prune -false -o -name *.go)
+	addlicense -f ./hack/license.txt $(shell find . -path ./hack/tools/vendor -prune -false -o -name *.sh)
+	addlicense -f ./hack/license.txt $(shell find . -path ./hack/tools/vendor -prune -false -o -name Dockerfile)
 
 .PHONY: checklicense
 checklicense:
 	# requires https://github.com/google/addlicense
-	# Only checks .go files at the moment
-	addlicense -check -f ./hack/license.txt $(shell find . -name *.go)
+	addlicense -check -f ./hack/license.txt $(shell find . -path ./hack/tools/vendor -prune -false -o -name *.go)
+	addlicense -check -f ./hack/license.txt $(shell find . -path ./hack/tools/vendor -prune -false -o -name *.sh)
+	addlicense -check -f ./hack/license.txt $(shell find . -path ./hack/tools/vendor -prune -false -o -name Dockerfile)

--- a/hack/deploy-nginx-example.sh
+++ b/hack/deploy-nginx-example.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 set -euxo pipefail
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 set -o errexit
 set -o nounset


### PR DESCRIPTION
* Exclude ./hack/tools/vendor directory to avoid bogus failures when
  running locally in a working directory with generated code
* Other filetypes will need to be added if we add them. If that becomes
an issue, we could consider excluding filetypes instead
* Add missing license string to a couple shell scripts