### PR TITLE
Add make test-full

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ e2e-down:
 .PHONY: test
 test: test-unit test-connectivity
 
+.PHONY: test-full
+test-full: test-unit build-images e2e-down e2e-up test-connectivity
+
 .PHONY: test-unit
 test-unit:
 	ginkgo -v -r $(PWD)/pkg $(PWD)/cmd/connectivity-registry


### PR DESCRIPTION
I've found myself doing something like this on a few occasions. Thoughts?

---

Runs unit tests, then builds images and runs the full test suite on a newly created set of kind clusters.

* Run unit tests first so that simple bugs are caught quickly
* Run build-images next to ensure they are available to e2e-up
  This is generally pretty quick if they've already been built
* Run e2e-down to tear down previous cluster, which may be in an unknown
  state. This also ensures that newly built images will be deployed.
* Then run e2e-up followed by the e2e tests (test-connectivity)

Running the commands selectively can be faster when you are aware of the
state of the system, but this is a more foolproof way to run the full
test-suite.