### PR TITLE
The connectivity controllers create resources in the same namespace as the controllers

### DIFF
--- a/apis/connectivity/v1alpha1/types.go
+++ b/apis/connectivity/v1alpha1/types.go
@@ -21,9 +21,6 @@ const (
 	ConnectivityRemoteRegistryLabel   = "connectivity.tanzu.vmware.com/remote-registry"
 	ConnectivityClusterNameLabel      = "connectivity.tanzu.vmware.com/cluster-name"
 	ConnectivityClusterNamespaceLabel = "connectivity.tanzu.vmware.com/cluster-namespace"
-
-	// TODO: Don't hardcode the namespace
-	ConnectivityNamespace = "cross-cluster-connectivity"
 )
 
 // +genclient

--- a/cmd/connectivity-publisher/main.go
+++ b/cmd/connectivity-publisher/main.go
@@ -58,8 +58,14 @@ func main() {
 	connectivityInformerFactory := connectivityinformers.NewSharedInformerFactory(connectivityClientset, 30*time.Second)
 	serviceRecordInformer := connectivityInformerFactory.Connectivity().V1alpha1().ServiceRecords()
 
+	namespace, exists := os.LookupEnv("NAMESPACE")
+	if !exists {
+		log.Error("NAMESPACE environment variable has not been set")
+		os.Exit(1)
+	}
+
 	httpProxyPublishController, err := httpproxypublish.NewHTTPProxyPublishController(
-		nodeInformer, contourInformer, serviceRecordInformer, connectivityClientset)
+		nodeInformer, contourInformer, serviceRecordInformer, connectivityClientset, namespace)
 	if err != nil {
 		log.Errorf("error creating HTTPProxyPublish controller: %v", err)
 		os.Exit(1)

--- a/cmd/connectivity-registry/main.go
+++ b/cmd/connectivity-registry/main.go
@@ -48,13 +48,24 @@ func main() {
 	serviceRecordInformer := connectivityInformerFactory.Connectivity().V1alpha1().ServiceRecords()
 	remoteRegistryInformer := connectivityInformerFactory.Connectivity().V1alpha1().RemoteRegistries()
 
+	namespace, exists := os.LookupEnv("NAMESPACE")
+	if !exists {
+		log.Error("NAMESPACE environment variable has not been set")
+		os.Exit(1)
+	}
+
 	registryServerController, err := registryserver.NewRegistryServerController(uint32(port), tlsCertPath, tlsKeyPath, serviceRecordInformer)
 	if err != nil {
 		log.Errorf("error creating RegistryServer controller: %v", err)
 		os.Exit(1)
 	}
 
-	registryClientController := registryclient.NewRegistryClientController(connectivityClientset, remoteRegistryInformer, serviceRecordInformer)
+	registryClientController := registryclient.NewRegistryClientController(
+		connectivityClientset,
+		remoteRegistryInformer,
+		serviceRecordInformer,
+		namespace,
+	)
 
 	stopCh := make(chan struct{})
 	connectivityInformerFactory.Start(stopCh)

--- a/cmd/connectivity-registry/main_test.go
+++ b/cmd/connectivity-registry/main_test.go
@@ -278,7 +278,7 @@ func newRegistryClientController(fakeClient *fake.Clientset, informer connectivi
 	remoteRegistryInformer := informer.Connectivity().V1alpha1().RemoteRegistries()
 	serviceRecordInformer := informer.Connectivity().V1alpha1().ServiceRecords()
 
-	return registryclient.NewRegistryClientController(fakeClient, remoteRegistryInformer, serviceRecordInformer)
+	return registryclient.NewRegistryClientController(fakeClient, remoteRegistryInformer, serviceRecordInformer, "cross-cluster-connectivity")
 }
 
 func newRegistryServerController(fakeClient *fake.Clientset, informer connectivityinformers.SharedInformerFactory, tlsCert, tlsKey []byte) (*registryserver.RegistryServerController, error) {

--- a/manifests/connectivity-publisher/deployment.yaml
+++ b/manifests/connectivity-publisher/deployment.yaml
@@ -33,6 +33,11 @@ spec:
         image: ghcr.io/vmware-tanzu/cross-cluster-connectivity/connectivity-publisher:dev
         # remove this when testing on a remote cluster
         imagePullPolicy: Never
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/manifests/connectivity-registry/deployment.yaml
+++ b/manifests/connectivity-registry/deployment.yaml
@@ -36,6 +36,11 @@ spec:
         args:
         - --tls-cert=/certs/tls.crt
         - --tls-key=/certs/tls.key
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 8000
         volumeMounts:

--- a/pkg/controllers/httpproxypublish/controller_test.go
+++ b/pkg/controllers/httpproxypublish/controller_test.go
@@ -845,8 +845,10 @@ func setupTestcase(t *testing.T, testCaseHttpProxy *contourv1.HTTPProxy, testCas
 	connectivityInformerFactory := connectivityinformers.NewSharedInformerFactory(connClientset, 30*time.Second)
 	serviceRecordInformer := connectivityInformerFactory.Connectivity().V1alpha1().ServiceRecords()
 
+	namespace := "cross-cluster-connectivity"
+
 	httpProxyPublishController, err := NewHTTPProxyPublishController(
-		nodeInformer, contourInformer, serviceRecordInformer, connClientset)
+		nodeInformer, contourInformer, serviceRecordInformer, connClientset, namespace)
 	if err != nil {
 		t.Fatalf("error creating HTTPProxyPublish controller: %v", err)
 	}

--- a/pkg/controllers/registryclient/client_controller.go
+++ b/pkg/controllers/registryclient/client_controller.go
@@ -38,18 +38,23 @@ type registryClient struct {
 	reDial chan struct{}
 	// send to this channel when RemoteRegistry resource is deleted
 	stopCh chan struct{}
+
+	namespace string
 }
 
 func newRegistryClient(
 	remoteRegistry *connectivityv1alpha1.RemoteRegistry,
 	connClientSet connectivityclientset.Interface,
-	serviceRecordLister connectivitylisters.ServiceRecordLister) *registryClient {
+	serviceRecordLister connectivitylisters.ServiceRecordLister,
+	namespace string,
+) *registryClient {
 	return &registryClient{
 		remoteRegistry:      remoteRegistry,
 		connClientSet:       connClientSet,
 		serviceRecordLister: serviceRecordLister,
 		reDial:              make(chan struct{}),
 		stopCh:              make(chan struct{}),
+		namespace:           namespace,
 	}
 }
 
@@ -216,7 +221,7 @@ func (r *registryClient) convertToKubernetesServiceRecord(fs *hamletv1alpha1.Fed
 			// TODO: account for FQDN ending in "."
 			// TODO: account for 64 character limit for resource names
 			Name:      generateServiceRecordName(fs.Fqdn, r.remoteRegistry.Name),
-			Namespace: connectivityv1alpha1.ConnectivityNamespace,
+			Namespace: r.namespace,
 			Labels: map[string]string{
 				connectivityv1alpha1.ImportedLabel:                   "",
 				connectivityv1alpha1.ConnectivityRemoteRegistryLabel: r.remoteRegistry.Name,

--- a/pkg/controllers/registryclient/controller_test.go
+++ b/pkg/controllers/registryclient/controller_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/vmware/hamlet/pkg/server"
 
 	log "github.com/sirupsen/logrus"
-	hamletv1alpha1 "github.com/vmware/hamlet/api/types/v1alpha1"
 	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
 	"github.com/vmware-tanzu/cross-cluster-connectivity/pkg/controllers/registryclient"
 	clientsetfake "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/clientset/versioned/fake"
 	connectivityinformers "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/informers/externalversions"
+	hamletv1alpha1 "github.com/vmware/hamlet/api/types/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -61,7 +61,9 @@ var _ = Describe("ClientController", func() {
 		remoteRegistryInformer := connectivityInformerFactory.Connectivity().V1alpha1().RemoteRegistries()
 		registryClientController := registryclient.NewRegistryClientController(connClientset,
 			remoteRegistryInformer,
-			serviceRecordInformer)
+			serviceRecordInformer,
+			"cross-cluster-connectivity",
+		)
 
 		connectivityInformerFactory.Start(nil)
 		connectivityInformerFactory.WaitForCacheSync(nil)

--- a/pkg/controllers/servicebinding/controller.go
+++ b/pkg/controllers/servicebinding/controller.go
@@ -273,7 +273,7 @@ func (s *ServiceBindingController) syncService(fs *connectivityv1alpha1.ServiceR
 	}
 
 	// fetch the latest Service from cache
-	currentService, err := s.serviceLister.Services(connectivityv1alpha1.ConnectivityNamespace).Get(serviceName)
+	currentService, err := s.serviceLister.Services(fs.Namespace).Get(serviceName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("error syncing Service for imported ServiceRecord %s: %v", fs.Namespace+"/"+fs.Name, err)
 	}
@@ -282,7 +282,7 @@ func (s *ServiceBindingController) syncService(fs *connectivityv1alpha1.ServiceR
 		newService := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            serviceName,
-				Namespace:       connectivityv1alpha1.ConnectivityNamespace,
+				Namespace:       fs.Namespace,
 				OwnerReferences: ownerReferences,
 				Annotations: map[string]string{
 					connectivityv1alpha1.FQDNAnnotation: fs.Spec.FQDN,
@@ -376,7 +376,7 @@ func (s *ServiceBindingController) syncEndpoints(fs *connectivityv1alpha1.Servic
 	endpointsName := serviceNameForFQDN(fs.Spec.FQDN)
 
 	// fetch the latest Endpoints from cache
-	currentEndpoints, err := s.endpointsLister.Endpoints(connectivityv1alpha1.ConnectivityNamespace).Get(endpointsName)
+	currentEndpoints, err := s.endpointsLister.Endpoints(fs.Namespace).Get(endpointsName)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("error syncing Endpoints for imported ServiceRecord %s: %v", fs.Namespace+"/"+fs.Name, err)
 	}
@@ -386,7 +386,7 @@ func (s *ServiceBindingController) syncEndpoints(fs *connectivityv1alpha1.Servic
 		endpoints := &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            endpointsName,
-				Namespace:       connectivityv1alpha1.ConnectivityNamespace,
+				Namespace:       fs.Namespace,
 				OwnerReferences: ownerReferences,
 			},
 			Subsets: desiredSubsets,

--- a/test/connectivity/exported_service_test.go
+++ b/test/connectivity/exported_service_test.go
@@ -15,11 +15,11 @@ import (
 	"path/filepath"
 	"time"
 
-	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+var connectivityNamespace = "cross-cluster-connectivity"
 
 var _ = Describe("Exported Service", func() {
 	var certsDir string
@@ -65,19 +65,19 @@ var _ = Describe("Exported Service", func() {
 		By("ensuring cross-cluster-connectivity managed resources are cleaned up")
 		Eventually(func() (string, error) {
 			output, err := kubectlWithConfig(sharedServiceClusterKubeConfig,
-				"get", "servicerecord", "-n", connectivityv1alpha1.ConnectivityNamespace)
+				"get", "servicerecord", "-n", connectivityNamespace)
 			return string(output), err
 		}, kubectlTimeout, kubectlInterval).ShouldNot(ContainSubstring("nginx.xcc.test"))
 
 		Eventually(func() (string, error) {
 			output, err := kubectlWithConfig(workloadClusterKubeConfig,
-				"get", "servicerecord", "-n", connectivityv1alpha1.ConnectivityNamespace)
+				"get", "servicerecord", "-n", connectivityNamespace)
 			return string(output), err
 		}, kubectlTimeout, kubectlInterval).ShouldNot(ContainSubstring("nginx.xcc.test"))
 
 		Eventually(func() (string, error) {
 			output, err := kubectlWithConfig(workloadClusterKubeConfig,
-				"get", "service", "-n", connectivityv1alpha1.ConnectivityNamespace)
+				"get", "service", "-n", connectivityNamespace)
 			return string(output), err
 		}, kubectlTimeout, kubectlInterval).ShouldNot(ContainSubstring("nginx-xcc-test"))
 	})
@@ -86,7 +86,7 @@ var _ = Describe("Exported Service", func() {
 		By("validating it doesn't discover the shared service on the workload cluster")
 		Consistently(func() (string, error) {
 			output, err := kubectlWithConfig(workloadClusterKubeConfig,
-				"get", "svc", "-n", connectivityv1alpha1.ConnectivityNamespace)
+				"get", "svc", "-n", connectivityNamespace)
 			return string(output), err
 		}, kubectlTimeout, kubectlInterval).ShouldNot(ContainSubstring("nginx-xcc-test"))
 


### PR DESCRIPTION
This change removes the hardcoded "cross-cluster-connectivity" namespace name from the controllers and instead uses the same namespace as the controllers for creating resources. The service publisher and registry now require the `NAMESPACE` environment to be set, which can be provided via the Kubernetes Downward API (https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/). The necessary changes to utilize the Downward API to inject the controller namespace in the `NAMESPACE` environment variable have been made to the deployment manifests provided in this repo.

For the service binder, there is a slight behavioral change from before.

Assuming the controllers are created in the "cross-cluster-connectivity" namespace:
- In the default case where the registry creates Service Records in the "cross-cluster-connectivity" namespace, Services will still be created in the "cross-cluster-connectivity" namespace.
- In the case of a ServiceRecord being created outside of the "cross-cluster-connectivity" namespace, the binder will create the Service in the same namespace as the ServiceRecord instead.

Fixes #11 