### PR TITLE
Watch service records within a single namespace

### DIFF
--- a/cmd/connectivity-publisher/main.go
+++ b/cmd/connectivity-publisher/main.go
@@ -55,14 +55,14 @@ func main() {
 	contourInformerFactory := dynamicinformer.NewDynamicSharedInformerFactory(dynamicClient, 30*time.Second)
 	contourInformer := contourInformerFactory.ForResource(contourv1.HTTPProxyGVR)
 
-	connectivityInformerFactory := connectivityinformers.NewSharedInformerFactory(connectivityClientset, 30*time.Second)
-	serviceRecordInformer := connectivityInformerFactory.Connectivity().V1alpha1().ServiceRecords()
-
 	namespace, exists := os.LookupEnv("NAMESPACE")
 	if !exists {
 		log.Error("NAMESPACE environment variable has not been set")
 		os.Exit(1)
 	}
+
+	connectivityInformerFactory := connectivityinformers.NewSharedInformerFactoryWithOptions(connectivityClientset, 30*time.Second, connectivityinformers.WithNamespace(namespace))
+	serviceRecordInformer := connectivityInformerFactory.Connectivity().V1alpha1().ServiceRecords()
 
 	httpProxyPublishController, err := httpproxypublish.NewHTTPProxyPublishController(
 		nodeInformer, contourInformer, serviceRecordInformer, connectivityClientset, namespace)


### PR DESCRIPTION
## Description
This changes the `connectivity-publisher` to only watch a singe namespace (the namespace the publisher is within). This assumes that any `ServiceRecord` resources within the `cross-cluster-connectivity` namespace are *owned* by the `connectivity-publisher` and no other controllers or users can create `ServiceRecords` within it. If a user or controller wanted to create their own `ServiceRecords` that would have to be done in a different namespace.

@jamiemonserrate and I considered using a label to designate ownership of a resource by the `connectivity-publisher`, but this complicates the migration path. E.g when I upgrade the `connectivity-publisher` that created `ServiceRecords` without labels then those resource are not considered owned by the `connectivity-publisher` and we would have to add logic to decide what resources we add the label to, to declare ownership.

If we decide that the controller can have ownership of all the ServiceRecords within the namespace, the problem is simplified.

## Related Issues

Fixes #23 