### PR TITLE
Do not delete Imported Service Records

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -408,6 +408,9 @@ function e2e_up() {
   # Create the workload cluster
   create_cluster $WORKLOAD_CLUSTER
 
+  # deploy addons for workload cluster
+  kubectl --kubeconfig ${WORKLOAD_CLUSTER_KUBECONFIG} apply -f manifests/contour/
+
   # Label the clusters so we can install our stuff with ClusterResourceSet
   kubectl_mgc -n default label cluster $SHARED_SERVICE_CLUSTER cross-cluster-connectivity=true --overwrite
   kubectl_mgc -n default label cluster $WORKLOAD_CLUSTER cross-cluster-connectivity=true --overwrite

--- a/pkg/controllers/servicerecorddelete/controller.go
+++ b/pkg/controllers/servicerecorddelete/controller.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
 	connectivityclientset "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/clientset/versioned"
 	connectivityinformers "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/informers/externalversions/connectivity/v1alpha1"
 	connectivitylisters "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/listers/connectivity/v1alpha1"
@@ -149,6 +150,10 @@ func (s *ServiceRecordOrphanDeleteController) sync(key string) error {
 	serviceRecord, err := s.serviceRecordLister.ServiceRecords(namespace).Get(name)
 	if err != nil {
 		return fmt.Errorf("error getting ServiceRecords from cache: %v", err)
+	}
+
+	if _, ok := serviceRecord.Labels[connectivityv1alpha1.ExportLabel]; !ok {
+		return nil
 	}
 
 	httpProxies, err := s.httpProxyLister.List(labels.Everything())


### PR DESCRIPTION
We were getting away with this so far in our e2e test because contour
wasn't present on the workload cluster, and therefore the Imported
ServiceRecords were failing to delete because the publisher wasn't able
to resolve the Contour HTTPProxy object.

Adding the contour deployment means that the publisher was now
erroneously deleting the Imported Service Records.

The publisher should only delete orphaned exported Service Records, and
not imported ones.

Signed-off-by: Jamie Monserrate <monserratej@vmware.com>

<!-- Thanks for contributing to Cross-cluster Connectivity! -->

<!--
Before submitting a pull request, make sure you read about our Contribution
Workflow here: https://github.com/vmware-tanzu/cross-cluster-connectivity/blob/main/CONTRIBUTING.md#contributor-workflow
-->

## Description
<!-- A clear and concise description of what the PR is adding or changing. -->

## Related Issues

<!--
All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request
description. Cross-cluster Connectivity operates according to the talk, then
code rule.  If you plan to submit a pull request for anything more than a typo
or obvious bug fix, first you should raise an issue to discuss your proposal,
before submitting any code.
-->
