### PR TITLE
Orphan Imported ServiceRecords are deleted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test-full: test-unit build-images e2e-down e2e-up test-connectivity
 
 .PHONY: test-unit
 test-unit:
-	ginkgo -v -r $(PWD)/pkg $(PWD)/cmd/connectivity-registry
+	ginkgo -v -race -r $(PWD)/pkg $(PWD)/cmd/connectivity-registry
 
 .PHONY: test-connectivity
 test-connectivity:

--- a/cmd/connectivity-registry/main.go
+++ b/cmd/connectivity-registry/main.go
@@ -34,8 +34,8 @@ func main() {
 	flag.IntVar(
 		&orphanImportedServiceRecordDeleteDelaySeconds,
 		"orphan-imported-service-record-delete-delay-seconds",
-		5 * 60,
-		"delay in seconds before an orphan imported service record is deleted"
+		5*60,
+		"delay in seconds before an orphan imported service record is deleted. if an exported service record has not been received by the end of this delay, the corresponding imported service record will be deleted.",
 	)
 	flag.Parse()
 
@@ -72,7 +72,7 @@ func main() {
 		remoteRegistryInformer,
 		serviceRecordInformer,
 		namespace,
-		orphanImportedServiceRecordDeleteDelaySeconds*time.Second,
+		time.Duration(orphanImportedServiceRecordDeleteDelaySeconds)*time.Second,
 	)
 
 	stopCh := make(chan struct{})

--- a/cmd/connectivity-registry/main.go
+++ b/cmd/connectivity-registry/main.go
@@ -22,14 +22,21 @@ import (
 
 func main() {
 	var (
-		tlsCertPath string
-		tlsKeyPath  string
-		port        int
+		tlsCertPath                                   string
+		tlsKeyPath                                    string
+		port                                          int
+		orphanImportedServiceRecordDeleteDelaySeconds int
 	)
 
 	flag.StringVar(&tlsCertPath, "tls-cert", "", "the path to the server TLS certificate")
 	flag.StringVar(&tlsKeyPath, "tls-key", "", "the path to the server TLS key")
 	flag.IntVar(&port, "port", 8000, "the serving port for the hamlet server")
+	flag.IntVar(
+		&orphanImportedServiceRecordDeleteDelaySeconds,
+		"orphan-imported-service-record-delete-delay-seconds",
+		5 * 60,
+		"delay in seconds before an orphan imported service record is deleted"
+	)
 	flag.Parse()
 
 	restConfig, err := rest.InClusterConfig()
@@ -65,7 +72,7 @@ func main() {
 		remoteRegistryInformer,
 		serviceRecordInformer,
 		namespace,
-		5*time.Minute, //or what?
+		orphanImportedServiceRecordDeleteDelaySeconds*time.Second,
 	)
 
 	stopCh := make(chan struct{})

--- a/cmd/connectivity-registry/main.go
+++ b/cmd/connectivity-registry/main.go
@@ -65,6 +65,7 @@ func main() {
 		remoteRegistryInformer,
 		serviceRecordInformer,
 		namespace,
+		5*time.Minute, //or what?
 	)
 
 	stopCh := make(chan struct{})

--- a/cmd/connectivity-registry/main_test.go
+++ b/cmd/connectivity-registry/main_test.go
@@ -278,7 +278,7 @@ func newRegistryClientController(fakeClient *fake.Clientset, informer connectivi
 	remoteRegistryInformer := informer.Connectivity().V1alpha1().RemoteRegistries()
 	serviceRecordInformer := informer.Connectivity().V1alpha1().ServiceRecords()
 
-	return registryclient.NewRegistryClientController(fakeClient, remoteRegistryInformer, serviceRecordInformer, "cross-cluster-connectivity")
+	return registryclient.NewRegistryClientController(fakeClient, remoteRegistryInformer, serviceRecordInformer, "cross-cluster-connectivity", 5*time.Minute)
 }
 
 func newRegistryServerController(fakeClient *fake.Clientset, informer connectivityinformers.SharedInformerFactory, tlsCert, tlsKey []byte) (*registryserver.RegistryServerController, error) {

--- a/doc/adr/0008-delete-orphan-import-service-records.md
+++ b/doc/adr/0008-delete-orphan-import-service-records.md
@@ -1,0 +1,89 @@
+#8 Client Side Orphan Service Record Deletion
+
+Date 2020-11-11
+Author: Jamie Monserrate, Tyler Schultz
+
+## Status
+
+Accepted
+
+## Context
+
+Imported ServiceRecords (client side ServiceRecords) will become orphaned when a
+delete message is missed. This may occur if the client were to become
+disconnected from the server when the delete occurred. The delete message would
+not be delivered and the RegistryClient would not know that an imported
+ServiceRecord is no longer valid.
+
+Upon a client establishing a new connection or on redial, the hamlet protocol
+specifies that all Records are to be sent to the client. There is no explicit
+message / procedure call to indicate that the bulk sync has completed.  Messages
+received after the bulk sync are indistinguishable from messages received during
+the bulk sync. Therefore, there is no way to know when it is safe to delete
+ServiceRecords for which has not been messaged.
+
+## Proposed Solution
+
+1. When the registry client starts, record in memory the ServiceRecords that are
+   received from the registry server. After a delay of 5mins (arbitrary) time,
+   list all of the imported ServiceRecords in the kube api, determine the list
+   of ServiceRecords that were not received, and then delete the orphan
+   ServiceRecords. The delay timer is only started upon the receiving the
+   initial ServiceRecord from the registry server. If the registry client were
+   to disconnect or redial, cancel the delayed delete action and start the whole
+   process over again.
+
+A danger of this approach is if for some reason the registry server were slow to
+send the state of the world, the client would improperly delete ServiceRecords
+that are still valid. This solution assumes the server is healthy and is able to
+message the exported ServiceRecords in a timely fashion.
+
+## Alternatives Considered
+
+1. Using a timer to deduce when the bulk sync has ended - Immediately following
+   a redial, start a countdown timer whenever a ServiceRecord is received. When
+   another ServiceRecord is received, restart the timer. The timer is renewed to
+   a time that is longer than the time between messages when the bulk sync is
+   happening. When the bulk sync is over the timer will elapse, indicating that
+   any ServiceRecords that have not received a corresponding message are safe
+   for deletion. Possible problems with this approach include falsely deducing
+   that the bulk sync is over and then deleting valid ServiceRecords, or
+   conversely falsely deducing the bulk sync is continuing when it’s actually
+   over and not deleting orphaned ServiceRecords.
+
+1. Drop all Service Records on the Client Side prior to a redial - On a new
+   connection or when attempting a redial, delete all the ServiceRecords on the
+   client cluster, and then rely on receiving all ServiceRecords from the server
+   to recreate the ServiceRecords. The major drawback of this approach is the
+   downtime when the ServiceRecord is deleted. If the connect / redial were to
+   fail, this would exacerbate the downtime - even though the services are
+   available.
+
+1. Add a “special” service record that indicates this is the end of the list -
+   Include a special ServiceRecord message that indicates the end of the bulk
+   sync. Client side ServiceRecords not received before the special
+   ServiceRecord can safely be deleted. This breaks the hamlet protocol, and
+   clients/servers not accustomed to this message would be broken by these
+   special messages. This approach also assumes that messages will be received
+   in the order they are sent, which is not indicated by the protocol.
+
+1. Deduce bulk sync has ended when updates trickle in - Creates are sent during
+   bulk sync, and updates are sent during steady state. So we could start
+   deleting orphans upon the first update message. This is not a viable option
+   because this is an implementation detail of the cross-cluster-connectivity
+   libraries, and not part of the hamlet protocol. Another issue with this
+   approach is that no updates may happen for an extended period of time,
+   prolonging the life of orphan ServiceRecords.
+
+1. Moving away from Hamlet and using Kube APIs directly - This option feels too
+   expensive to migrate to, locks us in to Kubernetes only, and would require
+   the registry client to have credentials to the kube API for a service
+   cluster.
+
+1. When the registry client reconnects assume that every Service Record is a
+   potential orphan. As the registry client receives events for Service Records,
+   remove them from the potential orphan. After X amount of time, delete
+   everything in the potential orphan list.
+
+## Related Reading
+https://github.com/vmware/hamlet/blob/master/spec/service-discovery.md

--- a/pkg/controllers/registryclient/internal/orphandeleter/orphan_deleter.go
+++ b/pkg/controllers/registryclient/internal/orphandeleter/orphan_deleter.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package orphandeleter
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/prometheus/common/log"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+
+	connectivityclientset "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/clientset/versioned"
+	connectivitylisters "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/listers/connectivity/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type OrphanDeleter struct {
+	serviceRecordLister  connectivitylisters.ServiceRecordLister
+	connClientSet        connectivityclientset.Interface
+	namespace            string
+	deleteOrphanTimer    *time.Timer
+	deleteOrphanDelay    time.Duration
+	remoteServiceRecords map[types.NamespacedName]struct{}
+
+	mutex sync.RWMutex
+}
+
+func NewOrphanDeleter(
+	serviceRecordLister connectivitylisters.ServiceRecordLister,
+	connClientSet connectivityclientset.Interface,
+	namespace string,
+	deleteOrphanDelay time.Duration,
+) *OrphanDeleter {
+	return &OrphanDeleter{
+		serviceRecordLister:  serviceRecordLister,
+		connClientSet:        connClientSet,
+		namespace:            namespace,
+		remoteServiceRecords: map[types.NamespacedName]struct{}{},
+		deleteOrphanDelay:    deleteOrphanDelay,
+	}
+}
+
+func (o *OrphanDeleter) Reset() {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	if o.deleteOrphanTimer != nil {
+		o.deleteOrphanTimer.Stop()
+		o.deleteOrphanTimer = nil
+	}
+	o.remoteServiceRecords = map[types.NamespacedName]struct{}{}
+}
+
+func (o *OrphanDeleter) AddRemoteServiceRecord(namespacedName types.NamespacedName) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+
+	if o.deleteOrphanTimer == nil {
+		o.deleteOrphanTimer = time.AfterFunc(o.deleteOrphanDelay, o.deleteOrphans)
+	}
+
+	o.remoteServiceRecords[namespacedName] = struct{}{}
+}
+
+func (o *OrphanDeleter) copyOfRemoteServiceRecords() map[types.NamespacedName]struct{} {
+	remoteServiceRecords := map[types.NamespacedName]struct{}{}
+	o.mutex.RLock()
+	defer o.mutex.RUnlock()
+	for k, v := range o.remoteServiceRecords {
+		remoteServiceRecords[k] = v
+	}
+	return remoteServiceRecords
+}
+
+func (o *OrphanDeleter) deleteOrphans() {
+	log.Infof("Cleaning up orphaned service records")
+
+	importedServiceRecords, err := o.listServiceRecords()
+	if err != nil {
+		log.Errorf("error listing service records: %s", err)
+	}
+
+	remoteServiceRecords := o.copyOfRemoteServiceRecords()
+	for namespacedName, _ := range importedServiceRecords {
+		if _, ok := remoteServiceRecords[namespacedName]; ok {
+			continue
+		}
+
+		log.Infof("Deleting Service Record: %s", namespacedName)
+		err := o.deleteServiceRecord(namespacedName)
+		if err != nil {
+			log.Errorf("error deleting orphaned service record: %s", err)
+		}
+	}
+}
+
+func (o *OrphanDeleter) listServiceRecords() (map[types.NamespacedName]struct{}, error) {
+	serviceRecords, err := o.serviceRecordLister.ServiceRecords(o.namespace).
+		List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	serviceRecordsNamespacedName := map[types.NamespacedName]struct{}{}
+	for _, serviceRecord := range serviceRecords {
+		namespacedName := types.NamespacedName{
+			Namespace: serviceRecord.Namespace,
+			Name:      serviceRecord.Name,
+		}
+		serviceRecordsNamespacedName[namespacedName] = struct{}{}
+	}
+
+	return serviceRecordsNamespacedName, nil
+}
+
+func (o *OrphanDeleter) deleteServiceRecord(namespacedName types.NamespacedName) error {
+	currentServiceRecord, err := o.serviceRecordLister.ServiceRecords(namespacedName.Namespace).Get(namespacedName.Name)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// already deleted
+			return nil
+		}
+
+		return fmt.Errorf("error getting current ServiceRecord: %v", err)
+	}
+
+	return o.connClientSet.ConnectivityV1alpha1().ServiceRecords(currentServiceRecord.Namespace).Delete(currentServiceRecord.Name, &metav1.DeleteOptions{})
+}

--- a/pkg/controllers/registryclient/internal/orphandeleter/orphan_deleter_test.go
+++ b/pkg/controllers/registryclient/internal/orphandeleter/orphan_deleter_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package orphandeleter_test
+
+import (
+	"log"
+	"time"
+
+	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
+	"github.com/vmware-tanzu/cross-cluster-connectivity/pkg/controllers/registryclient/internal/orphandeleter"
+	clientsetfake "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/clientset/versioned/fake"
+	connectivityinformers "github.com/vmware-tanzu/cross-cluster-connectivity/pkg/generated/informers/externalversions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apmachinerytypes "k8s.io/apimachinery/pkg/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+var _ = Describe("OrphanDeleter", func() {
+	var (
+		connClientset *clientsetfake.Clientset
+		orphanDeleter *orphandeleter.OrphanDeleter
+	)
+
+	BeforeEach(func() {
+		log.SetOutput(GinkgoWriter)
+
+		connClientset = clientsetfake.NewSimpleClientset()
+		connectivityInformerFactory := connectivityinformers.NewSharedInformerFactory(connClientset, 30*time.Second)
+		serviceRecordInformer := connectivityInformerFactory.Connectivity().V1alpha1().ServiceRecords()
+		deleteDelay := 100 * time.Millisecond
+		orphanDeleter = orphandeleter.NewOrphanDeleter(
+			serviceRecordInformer.Lister(),
+			connClientset,
+			"cross-cluster-connectivity",
+			deleteDelay,
+		)
+
+		_, err := connClientset.ConnectivityV1alpha1().ServiceRecords("cross-cluster-connectivity").
+			Create(&connectivityv1alpha1.ServiceRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-service.some.domain-06df7236",
+					Namespace: "cross-cluster-connectivity",
+				},
+				Spec: connectivityv1alpha1.ServiceRecordSpec{
+					FQDN: "some-service.some.domain",
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = connClientset.ConnectivityV1alpha1().ServiceRecords("cross-cluster-connectivity").
+			Create(&connectivityv1alpha1.ServiceRecord{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "orphaned-service-record-06df7236",
+					Namespace: "cross-cluster-connectivity",
+				},
+				Spec: connectivityv1alpha1.ServiceRecordSpec{
+					FQDN: "orphaned-service.some.domain",
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		connectivityInformerFactory.Start(nil)
+		connectivityInformerFactory.WaitForCacheSync(nil)
+	})
+
+	It("deletes service records that have not been removed prior to the timer running out", func() {
+		orphanDeleter.AddRemoteServiceRecord(apmachinerytypes.NamespacedName{
+			Namespace: "cross-cluster-connectivity",
+			Name:      "some-service.some.domain-06df7236",
+		})
+
+		Eventually(func() (*connectivityv1alpha1.ServiceRecordList, error) {
+			return connClientset.ConnectivityV1alpha1().ServiceRecords("cross-cluster-connectivity").
+				List(metav1.ListOptions{})
+		}, 2*time.Second, 100*time.Millisecond).Should(
+			MatchServiceRecords(
+				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"ObjectMeta": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal("some-service.some.domain-06df7236"),
+					}),
+				}),
+			),
+		)
+	})
+
+	It("does not remember service records added before a Reset", func() {
+		orphanDeleter.AddRemoteServiceRecord(apmachinerytypes.NamespacedName{
+			Namespace: "cross-cluster-connectivity",
+			Name:      "some-service.some.domain-06df7236",
+		})
+		orphanDeleter.Reset()
+
+		Consistently(func() (*connectivityv1alpha1.ServiceRecordList, error) {
+			return connClientset.ConnectivityV1alpha1().ServiceRecords("cross-cluster-connectivity").
+				List(metav1.ListOptions{})
+		}, 1*time.Second, 100*time.Millisecond).Should(
+			MatchServiceRecords(
+				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"ObjectMeta": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal("some-service.some.domain-06df7236"),
+					}),
+				}),
+				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"ObjectMeta": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal("orphaned-service-record-06df7236"),
+					}),
+				}),
+			),
+		)
+
+		orphanDeleter.AddRemoteServiceRecord(apmachinerytypes.NamespacedName{
+			Namespace: "cross-cluster-connectivity",
+			Name:      "some-service.some.domain-06df7236",
+		})
+
+		Eventually(func() (*connectivityv1alpha1.ServiceRecordList, error) {
+			return connClientset.ConnectivityV1alpha1().ServiceRecords("cross-cluster-connectivity").
+				List(metav1.ListOptions{})
+		}, 2*time.Second, 100*time.Millisecond).Should(
+			MatchServiceRecords(
+				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"ObjectMeta": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal("some-service.some.domain-06df7236"),
+					}),
+				}),
+			),
+		)
+	})
+})
+
+func MatchServiceRecords(matchers ...types.GomegaMatcher) types.GomegaMatcher {
+	return WithTransform(transformServiceRecordListToItems, ConsistOf(matchers))
+}
+
+func transformServiceRecordListToItems(srl *connectivityv1alpha1.ServiceRecordList) []connectivityv1alpha1.ServiceRecord {
+	if srl == nil || len(srl.Items) == 0 {
+		return nil
+	}
+	return srl.Items
+}

--- a/pkg/controllers/registryclient/internal/orphandeleter/registryclient_suite_test.go
+++ b/pkg/controllers/registryclient/internal/orphandeleter/registryclient_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package orphandeleter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestOrphanDeleter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OrphanDeleter Suite")
+}


### PR DESCRIPTION
If a delete message were to be missed while the client was
disconnected, the imported ServiceRecord would become orphaned.

The Hamlet protocol specifies that the server send the entire
record set to the client, then begin transmitting deltas. There is no
way to know when the server has finished sending the entire set and then
transitioned to the mode where only deltas are sent. This change
arbitrarily decides that after 5m, that the imported ServiceRecords on the client
that have not been sent by the server are orphans, and are deleted. This
change follows the recommendation from the hamlet docs whereby services
are deleted by use of a TTL strategy.

Also:
- test-unit make target runs with `-race`
- fix race in unit test

Fix #30

