### PR TITLE
Bump clusterctl to 0.3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
           sudo wget -O /usr/local/bin/clusterctl "https://github.com/kubernetes-sigs/cluster-api/releases/download/v${VERSION}/clusterctl-linux-amd64"
           sudo chmod +x /usr/local/bin/clusterctl
         env:
-          VERSION: 0.3.7
+          VERSION: 0.3.10
       - name: Download ytt
         run: |
           sudo wget -O /usr/local/bin/ytt "https://github.com/k14s/ytt/releases/download/v${VERSION}/ytt-linux-amd64"


### PR DESCRIPTION
<!-- Thanks for contributing to Cross-cluster Connectivity! -->

<!--
Before submitting a pull request, make sure you read about our Contribution
Workflow here: https://github.com/vmware-tanzu/cross-cluster-connectivity/blob/main/CONTRIBUTING.md#contributor-workflow
-->

## Description
<!-- A clear and concise description of what the PR is adding or changing. -->
Bump clusterctl in the `test` workflow to 0.3.10 to get our e2e-tests passing again. For whatever reason `0.3.7` causes the tests to fail with:

```
error: timed out waiting for the condition on deployments/capi-controller-manager
make: *** [e2e-up] Error 1
Makefile:21: recipe for target 'e2e-up' failed
Error: Process completed with exit code 2.
```
[Source](https://github.com/vmware-tanzu/cross-cluster-connectivity/runs/1415112652?check_suite_focus=true#step:9:44)

## Related Issues

<!--
All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request
description. Cross-cluster Connectivity operates according to the talk, then
code rule.  If you plan to submit a pull request for anything more than a typo
or obvious bug fix, first you should raise an issue to discuss your proposal,
before submitting any code.
-->
