### PR TITLE
Update DNS to support wildcards and EndpointSlices

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,3 +39,4 @@ jobs:
           VERSION: 0.30.0
       - run: make e2e-up
       - run: make test-connectivity
+      - run: make test-cluster-api-dns

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ e2e-down:
 test: test-unit test-connectivity
 
 .PHONY: test-full
-test-full: test-unit build-images e2e-down e2e-up test-connectivity
+test-full: test-unit build-images e2e-down e2e-up test-connectivity test-cluster-api-dns
 
 .PHONY: test-unit
 test-unit:
@@ -39,6 +39,12 @@ test-connectivity:
 	CLUSTER_ONE_KUBECONFIG=$(WORKLOAD_CLUSTER_KUBECONFIG) \
 	CLUSTER_TWO_KUBECONFIG=$(SHARED_SERVICE_CLUSTER_KUBECONFIG) \
 	ginkgo -v -p $(PWD)/test/connectivity
+
+.PHONY: test-cluster-api-dns
+test-cluster-api-dns:
+	CLUSTER_ONE_KUBECONFIG=$(WORKLOAD_CLUSTER_KUBECONFIG) \
+	CLUSTER_TWO_KUBECONFIG=$(SHARED_SERVICE_CLUSTER_KUBECONFIG) \
+	ginkgo -v -p $(PWD)/test/clusterapidns
 
 .PHONY: build-images
 build-images: build-connectivity-publisher build-connectivity-binder build-connectivity-registry build-connectivity-dns

--- a/apis/connectivity/v1alpha1/types.go
+++ b/apis/connectivity/v1alpha1/types.go
@@ -14,6 +14,7 @@ const (
 	ImportedLabel           = "connectivity.tanzu.vmware.com/imported"
 	GlobalVIPAnnotation     = "connectivity.tanzu.vmware.com/vip"
 	FQDNAnnotation          = "connectivity.tanzu.vmware.com/fqdn"
+	DNSHostnameAnnotation   = "connectivity.tanzu.vmware.com/dns-hostname"
 	// ServicePortAnnotation is an annotation used to specify the client-side Service
 	// port binding for a ServiceRecord. This annotation is temporary until hamlet
 	// v1alpha2 supports port mappings.

--- a/manifests/connectivity-dns/deployment.yaml
+++ b/manifests/connectivity-dns/deployment.yaml
@@ -77,6 +77,14 @@ rules:
       - list
       - watch
       - get
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
+      - get
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/controllers/servicedns/cache_test.go
+++ b/pkg/controllers/servicedns/cache_test.go
@@ -16,20 +16,18 @@ var _ = Describe("DNSCache", func() {
 		It("inserts the cache entry if it does not exist", func() {
 			cache := new(servicedns.DNSCache)
 			Expect(cache.Lookup("a.b.c")).To(BeNil())
-			Expect(cache.LookupByServiceKey("12345-abc")).To(BeNil())
 
 			dnsCacheEntry := servicedns.DNSCacheEntry{
 				ServiceKey: "12345-abc",
 				FQDN:       "a.b.c",
-				IP:         net.ParseIP("1.2.3.4"),
+				IPs:        []net.IP{net.ParseIP("1.2.3.4")},
 			}
 			cache.Upsert(dnsCacheEntry)
 
 			Expect(cache.Lookup("a.b.c")).To(Equal(&dnsCacheEntry))
-			Expect(cache.LookupByServiceKey("12345-abc")).To(Equal(&dnsCacheEntry))
 		})
 
-		Context("if the cache entry does exist and the service key changes", func() {
+		Context("if the cache entry does exist and the key changes", func() {
 			var (
 				cache    *servicedns.DNSCache
 				oldEntry servicedns.DNSCacheEntry
@@ -40,25 +38,21 @@ var _ = Describe("DNSCache", func() {
 				oldEntry = servicedns.DNSCacheEntry{
 					ServiceKey: "12345-abc-old",
 					FQDN:       "a.b.c",
-					IP:         net.ParseIP("1.2.3.4"),
+					IPs:        []net.IP{net.ParseIP("1.2.3.4")},
 				}
 				cache.Upsert(oldEntry)
 			})
 
 			It("updates the cache entry", func() {
 				Expect(cache.Lookup("a.b.c")).To(Equal(&oldEntry))
-				Expect(cache.LookupByServiceKey("12345-abc")).To(BeNil())
-				Expect(cache.LookupByServiceKey("12345-abc-old")).To(Equal(&oldEntry))
 
 				newEntry := servicedns.DNSCacheEntry{
 					ServiceKey: "12345-abc",
 					FQDN:       "a.b.c",
-					IP:         net.ParseIP("4.5.6.7"),
+					IPs:        []net.IP{net.ParseIP("4.5.6.7")},
 				}
 				cache.Upsert(newEntry)
 				Expect(cache.Lookup("a.b.c")).To(Equal(&newEntry))
-				Expect(cache.LookupByServiceKey("12345-abc")).To(Equal(&newEntry))
-				Expect(cache.LookupByServiceKey("12345-abc-old")).To(BeNil())
 			})
 		})
 
@@ -73,7 +67,7 @@ var _ = Describe("DNSCache", func() {
 				oldEntry = servicedns.DNSCacheEntry{
 					ServiceKey: "12345-abc",
 					FQDN:       "a.b.c",
-					IP:         net.ParseIP("1.2.3.4"),
+					IPs:        []net.IP{net.ParseIP("1.2.3.4")},
 				}
 				cache.Upsert(oldEntry)
 			})
@@ -81,17 +75,33 @@ var _ = Describe("DNSCache", func() {
 			It("updates the cache entry", func() {
 				Expect(cache.Lookup("a.b.c")).To(Equal(&oldEntry))
 				Expect(cache.Lookup("b.c.d")).To(BeNil())
-				Expect(cache.LookupByServiceKey("12345-abc")).To(Equal(&oldEntry))
 
 				newEntry := servicedns.DNSCacheEntry{
 					ServiceKey: "12345-abc",
 					FQDN:       "b.c.d",
-					IP:         net.ParseIP("4.5.6.7"),
+					IPs:        []net.IP{net.ParseIP("4.5.6.7")},
 				}
 				cache.Upsert(newEntry)
 				Expect(cache.Lookup("a.b.c")).To(BeNil())
 				Expect(cache.Lookup("b.c.d")).To(Equal(&newEntry))
-				Expect(cache.LookupByServiceKey("12345-abc")).To(Equal(&newEntry))
+			})
+		})
+
+		Context("if the domain name has a wildcard", func() {
+			It("can lookup any fqdn that matches the wildcard", func() {
+				cache := new(servicedns.DNSCache)
+				dnsCacheEntry := servicedns.DNSCacheEntry{
+					EndpointSliceKey: "12345-abc",
+					FQDN:             "*.b.c",
+					IPs:              []net.IP{net.ParseIP("1.2.3.4")},
+				}
+				cache.Upsert(dnsCacheEntry)
+
+				Expect(cache.Lookup("*.b.c")).To(Equal(&dnsCacheEntry))
+				Expect(cache.Lookup("foo.b.c")).To(Equal(&dnsCacheEntry))
+				Expect(cache.Lookup("bar.b.c")).To(Equal(&dnsCacheEntry))
+				Expect(cache.Lookup("foo.bar.b.c")).To(Equal(&dnsCacheEntry))
+				Expect(cache.Lookup("foo.bar.baz.b.c")).To(Equal(&dnsCacheEntry))
 			})
 		})
 	})
@@ -108,19 +118,17 @@ var _ = Describe("DNSCache", func() {
 				oldEntry = servicedns.DNSCacheEntry{
 					ServiceKey: "12345-abc-old",
 					FQDN:       "a.b.c",
-					IP:         net.ParseIP("1.2.3.4"),
+					IPs:        []net.IP{net.ParseIP("1.2.3.4")},
 				}
 				cache.Upsert(oldEntry)
 			})
 
 			It("deletes the cache entry if it does exist", func() {
 				Expect(cache.Lookup("a.b.c")).To(Equal(&oldEntry))
-				Expect(cache.LookupByServiceKey("12345-abc-old")).To(Equal(&oldEntry))
 
 				cache.Delete("a.b.c")
 
 				Expect(cache.Lookup("a.b.c")).To(BeNil())
-				Expect(cache.LookupByServiceKey("12345-abc-old")).To(BeNil())
 			})
 		})
 
@@ -136,37 +144,112 @@ var _ = Describe("DNSCache", func() {
 	Describe("DeleteByServiceKey", func() {
 		Context("if the cache entry does exist", func() {
 			var (
-				cache    *servicedns.DNSCache
-				oldEntry servicedns.DNSCacheEntry
+				cache *servicedns.DNSCache
+				entry servicedns.DNSCacheEntry
 			)
 
 			BeforeEach(func() {
 				cache = new(servicedns.DNSCache)
-				oldEntry = servicedns.DNSCacheEntry{
-					ServiceKey: "12345-abc-old",
+				entry = servicedns.DNSCacheEntry{
+					ServiceKey: "12345-abc",
 					FQDN:       "a.b.c",
-					IP:         net.ParseIP("1.2.3.4"),
+					IPs:        []net.IP{net.ParseIP("1.2.3.4")},
 				}
-				cache.Upsert(oldEntry)
+				cache.Upsert(entry)
 			})
 
 			It("deletes the cache entry if it does exist", func() {
-				Expect(cache.Lookup("a.b.c")).To(Equal(&oldEntry))
-				Expect(cache.LookupByServiceKey("12345-abc-old")).To(Equal(&oldEntry))
+				Expect(cache.Lookup("a.b.c")).To(Equal(&entry))
 
-				cache.DeleteByServiceKey("12345-abc-old")
+				cache.DeleteByServiceKey("12345-abc")
 
 				Expect(cache.Lookup("a.b.c")).To(BeNil())
-				Expect(cache.LookupByServiceKey("12345-abc-old")).To(BeNil())
+			})
+
+			When("the entry does not have an service key", func() {
+				var otherEntry servicedns.DNSCacheEntry
+
+				BeforeEach(func() {
+					otherEntry = servicedns.DNSCacheEntry{
+						EndpointSliceKey: entry.ServiceKey,
+						FQDN:             "a.b.d",
+						IPs:              []net.IP{net.ParseIP("1.2.3.5")},
+					}
+					cache.Upsert(otherEntry)
+				})
+
+				It("does not delete the cache entry by endpoint slice key", func() {
+					Expect(cache.Lookup("a.b.d")).To(Equal(&otherEntry))
+
+					cache.DeleteByServiceKey("12345-abc")
+
+					Expect(cache.Lookup("a.b.d")).To(Equal(&otherEntry))
+				})
 			})
 		})
 
 		It("does nothing if the entry does not exist", func() {
 			cache := new(servicedns.DNSCache)
 
-			Expect(cache.LookupByServiceKey("12345-abc-foo")).To(BeNil())
-			cache.DeleteByServiceKey("12345-abc-foo")
-			Expect(cache.LookupByServiceKey("12345-abc-foo")).To(BeNil())
+			Expect(cache.Lookup("a.b.c")).To(BeNil())
+			cache.DeleteByServiceKey("12345-abc")
+			Expect(cache.Lookup("a.b.c")).To(BeNil())
+		})
+	})
+
+	Describe("DeleteByEndpointSliceKey", func() {
+		Context("if the cache entry does exist", func() {
+			var (
+				cache *servicedns.DNSCache
+				entry servicedns.DNSCacheEntry
+			)
+
+			BeforeEach(func() {
+				cache = new(servicedns.DNSCache)
+				entry = servicedns.DNSCacheEntry{
+					EndpointSliceKey: "12345-abc",
+					FQDN:             "a.b.c",
+					IPs:              []net.IP{net.ParseIP("1.2.3.4")},
+				}
+				cache.Upsert(entry)
+			})
+
+			It("deletes the cache entry if it does exist", func() {
+				Expect(cache.Lookup("a.b.c")).To(Equal(&entry))
+
+				cache.DeleteByEndpointSliceKey("12345-abc")
+
+				Expect(cache.Lookup("a.b.c")).To(BeNil())
+			})
+
+			When("the entry does not have an endpoint slice key", func() {
+				var otherEntry servicedns.DNSCacheEntry
+
+				BeforeEach(func() {
+					otherEntry = servicedns.DNSCacheEntry{
+						ServiceKey: entry.EndpointSliceKey,
+						FQDN:       "a.b.d",
+						IPs:        []net.IP{net.ParseIP("1.2.3.5")},
+					}
+					cache.Upsert(otherEntry)
+				})
+
+				It("does not delete the cache entry by endpoint slice key", func() {
+					Expect(cache.Lookup("a.b.d")).To(Equal(&otherEntry))
+
+					cache.DeleteByEndpointSliceKey("12345-abc")
+
+					Expect(cache.Lookup("a.b.d")).To(Equal(&otherEntry))
+				})
+			})
+		})
+
+		It("does nothing if the entry does not exist", func() {
+			cache := new(servicedns.DNSCache)
+
+			Expect(cache.Lookup("a.b.c")).To(BeNil())
+			cache.DeleteByEndpointSliceKey("12345-abc-foo")
+			Expect(cache.Lookup("a.b.c")).To(BeNil())
 		})
 	})
 
@@ -176,6 +259,54 @@ var _ = Describe("DNSCache", func() {
 			Expect(cache.IsPopulated()).To(BeFalse())
 			cache.SetPopulated()
 			Expect(cache.IsPopulated()).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("DNSCacheEntry", func() {
+	var entry servicedns.DNSCacheEntry
+
+	Describe("GetKey", func() {
+		When("only a service key is provided", func() {
+			BeforeEach(func() {
+				entry.ServiceKey = "namespace/service-name"
+				entry.EndpointSliceKey = ""
+			})
+
+			It("returns the service key", func() {
+				Expect(entry.GetKey()).To(Equal("service/namespace/service-name"))
+			})
+		})
+		When("only an endpoint slice key is provided", func() {
+			BeforeEach(func() {
+				entry.ServiceKey = ""
+				entry.EndpointSliceKey = "namespace/endpoint-slice-name"
+			})
+
+			It("returns the endpoint slice key", func() {
+				Expect(entry.GetKey()).To(Equal("endpointslice/namespace/endpoint-slice-name"))
+			})
+		})
+		When("both a service key and an endpoint slice key are provided", func() {
+			BeforeEach(func() {
+				entry.ServiceKey = "namespace/service-name"
+				entry.EndpointSliceKey = "namespace/endpoint-slice-name"
+			})
+
+			It("returns the service key", func() {
+				Expect(entry.GetKey()).To(Equal("service/namespace/service-name"))
+			})
+		})
+
+		When("neither a service key nor an endpoint slice key are provided", func() {
+			BeforeEach(func() {
+				entry.ServiceKey = ""
+				entry.EndpointSliceKey = ""
+			})
+
+			It("returns an empty string", func() {
+				Expect(entry.GetKey()).To(Equal(""))
+			})
 		})
 	})
 })

--- a/pkg/controllers/servicedns/endpoint_slice_controller_test.go
+++ b/pkg/controllers/servicedns/endpoint_slice_controller_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package servicedns_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
+	"github.com/vmware-tanzu/cross-cluster-connectivity/pkg/controllers/servicedns"
+	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EndpointSliceDNS", func() {
+	var (
+		kubeClientset *kubefake.Clientset
+		dnsCache      *servicedns.DNSCache
+
+		endpointSlice *discoveryv1beta1.EndpointSlice
+	)
+
+	BeforeEach(func() {
+		kubeClientset = kubefake.NewSimpleClientset()
+		kubeInformerFactory := informers.NewSharedInformerFactory(kubeClientset, 30*time.Second)
+		endpointSliceInformer := kubeInformerFactory.Discovery().V1beta1().EndpointSlices()
+
+		dnsCache = new(servicedns.DNSCache)
+
+		endpointSliceDNSController := servicedns.NewEndpointSliceDNSController(endpointSliceInformer, dnsCache)
+
+		kubeInformerFactory.Start(nil)
+		kubeInformerFactory.WaitForCacheSync(nil)
+
+		go endpointSliceDNSController.Run(1, nil)
+	})
+
+	When("an EndpointSlice exists with a DNS hostname annotation", func() {
+		BeforeEach(func() {
+			endpointSlice = &discoveryv1beta1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-endpoint-slice",
+					Namespace: "cross-cluster-connectivity",
+					Annotations: map[string]string{
+						connectivityv1alpha1.DNSHostnameAnnotation: "foo.xcc.test",
+					},
+				},
+				AddressType: discoveryv1beta1.AddressTypeIPv4,
+				Endpoints: []discoveryv1beta1.Endpoint{
+					{
+						Addresses: []string{"1.2.3.4", "1.2.3.5"},
+					},
+					{
+						Addresses: []string{"1.2.3.6", "1.2.3.7"},
+					},
+				},
+			}
+
+			_, err := kubeClientset.DiscoveryV1beta1().EndpointSlices("cross-cluster-connectivity").
+				Create(context.Background(), endpointSlice, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("populates the dns cache with the domain name and endpoints from the EndpointSlice", func() {
+			Eventually(func() ([]string, error) {
+				cacheEntry := dnsCache.Lookup("foo.xcc.test")
+				if cacheEntry == nil {
+					return []string{}, fmt.Errorf("fqdn foo.xcc.test does not exist in dns cache")
+				}
+				return ipsToStrings(cacheEntry.IPs), nil
+			}, time.Second*5, time.Second).Should(ConsistOf("1.2.3.4", "1.2.3.5", "1.2.3.6", "1.2.3.7"))
+		})
+
+		When("the domain name is a wildcard domain", func() {
+			BeforeEach(func() {
+				endpointSlice = &discoveryv1beta1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-wildcard-endpoint-slice",
+						Namespace: "cross-cluster-connectivity",
+						Annotations: map[string]string{
+							connectivityv1alpha1.DNSHostnameAnnotation: "*.gateway.xcc.test",
+						},
+					},
+					AddressType: discoveryv1beta1.AddressTypeIPv4,
+					Endpoints: []discoveryv1beta1.Endpoint{
+						{
+							Addresses: []string{"1.2.3.4"},
+						},
+					},
+				}
+
+				_, err := kubeClientset.DiscoveryV1beta1().EndpointSlices("cross-cluster-connectivity").
+					Create(context.Background(), endpointSlice, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("can lookup any domain on the wildcard domain", func() {
+				Eventually(func() ([]string, error) {
+					cacheEntry := dnsCache.Lookup("foo.gateway.xcc.test")
+					if cacheEntry == nil {
+						return []string{}, fmt.Errorf("fqdn foo.gateway.xcc.test does not exist in dns cache")
+					}
+					return ipsToStrings(cacheEntry.IPs), nil
+				}, time.Second*5, time.Second).Should(ConsistOf("1.2.3.4"))
+
+				Eventually(func() ([]string, error) {
+					cacheEntry := dnsCache.Lookup("bar.gateway.xcc.test")
+					if cacheEntry == nil {
+						return []string{}, fmt.Errorf("fqdn bar.gateway.xcc.test does not exist in dns cache")
+					}
+					return ipsToStrings(cacheEntry.IPs), nil
+				}, time.Second*5, time.Second).Should(ConsistOf("1.2.3.4"))
+			})
+		})
+
+		When("the domain name is an IPv6 domain", func() {
+			BeforeEach(func() {
+				endpointSlice = &discoveryv1beta1.EndpointSlice{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-ipv4-endpoint-slice",
+						Namespace: "cross-cluster-connectivity",
+						Annotations: map[string]string{
+							connectivityv1alpha1.DNSHostnameAnnotation: "bar.xcc.test",
+						},
+					},
+					AddressType: discoveryv1beta1.AddressTypeIPv6,
+					Endpoints: []discoveryv1beta1.Endpoint{
+						{
+							Addresses: []string{"::1"},
+						},
+					},
+				}
+
+				_, err := kubeClientset.DiscoveryV1beta1().EndpointSlices("cross-cluster-connectivity").
+					Create(context.Background(), endpointSlice, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("does not allow lookups on this domain", func() {
+				Consistently(func() error {
+					cacheEntry := dnsCache.Lookup("bar.xcc.test")
+					if cacheEntry == nil {
+						return fmt.Errorf("fqdn bar.xcc.test does not exist in dns cache")
+					}
+					return nil
+				}, time.Second*5, time.Second).ShouldNot(Succeed())
+			})
+		})
+
+		When("the EndpointSlice is updated", func() {
+			BeforeEach(func() {
+				Eventually(func() ([]string, error) {
+					cacheEntry := dnsCache.Lookup("foo.xcc.test")
+					if cacheEntry == nil {
+						return []string{}, fmt.Errorf("fqdn foo.xcc.test does not exist in dns cache")
+					}
+					return ipsToStrings(cacheEntry.IPs), nil
+				}, time.Second*5, time.Second).Should(ConsistOf("1.2.3.4", "1.2.3.5", "1.2.3.6", "1.2.3.7"))
+			})
+
+			It("updates the dns cache", func() {
+				endpointSlice.ObjectMeta.Annotations[connectivityv1alpha1.DNSHostnameAnnotation] = "*.updated-gateway.xcc.test"
+				_, err := kubeClientset.DiscoveryV1beta1().EndpointSlices("cross-cluster-connectivity").
+					Update(context.Background(), endpointSlice, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() ([]string, error) {
+					cacheEntry := dnsCache.Lookup("foo.updated-gateway.xcc.test")
+					if cacheEntry == nil {
+						return []string{}, fmt.Errorf("fqdn foo.updated-gateway.xcc.test does not exist in dns cache")
+					}
+					return ipsToStrings(cacheEntry.IPs), nil
+				}, time.Second*5, time.Second).Should(ConsistOf("1.2.3.4", "1.2.3.5", "1.2.3.6", "1.2.3.7"))
+				Expect(dnsCache.Lookup("foo.gateway.xcc.test")).To(BeNil())
+			})
+		})
+	})
+
+	When("the EndpointSlice does not have a domain name annotation set", func() {
+		BeforeEach(func() {
+			endpointSlice = &discoveryv1beta1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "some-ipv4-endpoint-slice",
+					Namespace:   "cross-cluster-connectivity",
+					Annotations: map[string]string{},
+				},
+				AddressType: discoveryv1beta1.AddressTypeIPv4,
+				Endpoints: []discoveryv1beta1.Endpoint{
+					{
+						Addresses: []string{"10.4.5.6"},
+					},
+				},
+			}
+
+			_, err := kubeClientset.DiscoveryV1beta1().EndpointSlices("cross-cluster-connectivity").
+				Create(context.Background(), endpointSlice, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not allow lookups on this domain", func() {
+			Consistently(func() error {
+				cacheEntry := dnsCache.Lookup("")
+				if cacheEntry == nil {
+					return fmt.Errorf("fqdn '' does not exist in dns cache")
+				}
+				return nil
+			}, time.Second*5, time.Second).ShouldNot(Succeed())
+		})
+	})
+
+	When("a EndpointSlice is deleted", func() {
+		BeforeEach(func() {
+			endpointSlice = &discoveryv1beta1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-endpoint-slice",
+					Namespace: "cross-cluster-connectivity",
+					Annotations: map[string]string{
+						connectivityv1alpha1.DNSHostnameAnnotation: "*.gateway.xcc.test",
+					},
+				},
+				AddressType: discoveryv1beta1.AddressTypeIPv4,
+				Endpoints: []discoveryv1beta1.Endpoint{
+					{
+						Addresses: []string{"1.2.3.4"},
+					},
+				},
+			}
+
+			_, err := kubeClientset.DiscoveryV1beta1().EndpointSlices("cross-cluster-connectivity").
+				Create(context.Background(), endpointSlice, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() ([]string, error) {
+				cacheEntry := dnsCache.Lookup("foo.gateway.xcc.test")
+				if cacheEntry == nil {
+					return []string{}, fmt.Errorf("fqdn foo.gateway.xcc.test does not exist in dns cache")
+				}
+				return ipsToStrings(cacheEntry.IPs), nil
+			}, time.Second*5, time.Second).Should(ConsistOf("1.2.3.4"))
+
+			err = kubeClientset.DiscoveryV1beta1().EndpointSlices("cross-cluster-connectivity").
+				Delete(context.Background(), "some-endpoint-slice", metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("removes the entry from the dns cache", func() {
+			Eventually(func() []string {
+				cacheEntry := dnsCache.Lookup("foo.gateway.xcc.test")
+				if cacheEntry == nil {
+					return []string{}
+				}
+				return ipsToStrings(cacheEntry.IPs)
+			}, time.Second*5, time.Second).Should(BeEmpty())
+		})
+	})
+})
+
+func ipsToStrings(ips []net.IP) []string {
+	strIPs := []string{}
+	for _, ip := range ips {
+		strIPs = append(strIPs, ip.String())
+	}
+
+	return strIPs
+}

--- a/pkg/controllers/servicedns/service_controller.go
+++ b/pkg/controllers/servicedns/service_controller.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package servicedns
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	informercorev1 "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type ServiceDNSController struct {
+	scheme *runtime.Scheme
+
+	serviceInformer informercorev1.ServiceInformer
+	dnsCache        *DNSCache
+
+	workqueue workqueue.RateLimitingInterface
+}
+
+func NewServiceDNSController(serviceInformer informercorev1.ServiceInformer, dnsCache *DNSCache) *ServiceDNSController {
+	controller := &ServiceDNSController{
+		scheme:          runtime.NewScheme(),
+		serviceInformer: serviceInformer,
+		dnsCache:        dnsCache,
+		workqueue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Services"),
+	}
+
+	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: controller.enqueue,
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			controller.enqueue(newObj)
+		},
+		DeleteFunc: controller.handleDelete,
+	})
+
+	return controller
+}
+
+func (s *ServiceDNSController) Run(threads int, stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+	defer s.workqueue.ShutDown()
+
+	log.Info("Starting ServiceDNS controller")
+	for i := 0; i < threads; i++ {
+		go wait.Until(s.runWorker, time.Second, stopCh)
+	}
+
+	log.Info("Started workers")
+	<-stopCh
+	log.Info("Shutting down workers")
+
+	return nil
+}
+
+func (s *ServiceDNSController) runWorker() {
+	for s.processNextWorkItem() {
+	}
+}
+
+func (s *ServiceDNSController) processNextWorkItem() bool {
+	obj, shutdown := s.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	err := func(obj interface{}) error {
+		defer s.workqueue.Done(obj)
+
+		var key string
+		var ok bool
+		if key, ok = obj.(string); !ok {
+			s.workqueue.Forget(obj)
+			utilruntime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+
+		if err := s.sync(key); err != nil {
+			s.workqueue.AddRateLimited(key)
+			return fmt.Errorf("error syncing '%s': %s, requeuing", key, err.Error())
+		}
+
+		s.workqueue.Forget(obj)
+		log.Infof("Successfully synced Service '%s'", key)
+		return nil
+	}(obj)
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+func (s *ServiceDNSController) sync(key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	service, err := s.serviceInformer.Lister().Services(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			s.dnsCache.DeleteByServiceKey(key)
+
+			return nil
+		}
+
+		return err
+	}
+
+	fqdn := service.Annotations[connectivityv1alpha1.FQDNAnnotation]
+
+	clusterIP := net.ParseIP(service.Spec.ClusterIP)
+	if clusterIP == nil {
+		utilruntime.HandleError(fmt.Errorf("invalid cluster ip: %s", service.Spec.ClusterIP))
+		return nil
+	}
+
+	s.dnsCache.Upsert(DNSCacheEntry{
+		ServiceKey: key,
+		FQDN:       fqdn,
+		IPs:        []net.IP{clusterIP},
+	})
+
+	return nil
+}
+
+func (s *ServiceDNSController) enqueue(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return
+	}
+
+	s.workqueue.Add(key)
+}
+
+func (s *ServiceDNSController) handleDelete(obj interface{}) {
+	var object metav1.Object
+	var ok bool
+	if object, ok = obj.(metav1.Object); !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding object, invalid type"))
+			return
+		}
+		object, ok = tombstone.Obj.(metav1.Object)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
+			return
+		}
+	}
+
+	s.enqueue(object)
+}

--- a/pkg/coredns/plugins/crosscluster/crosscluster.go
+++ b/pkg/coredns/plugins/crosscluster/crosscluster.go
@@ -38,11 +38,13 @@ func (c *CrossCluster) Services(ctx context.Context, state request.Request, exac
 		return nil, errNameNotFound
 	}
 
-	services := []msg.Service{
-		{
-			Host: cacheEntry.IP.String(),
+	services := []msg.Service{}
+
+	for _, ip := range cacheEntry.IPs {
+		services = append(services, msg.Service{
+			Host: ip.String(),
 			TTL:  30,
-		},
+		})
 	}
 
 	return services, nil

--- a/test/clusterapidns/clusterapidns_suite_test.go
+++ b/test/clusterapidns/clusterapidns_suite_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package connectivity_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	kubectlTimeout  = 1 * time.Minute
+	kubectlInterval = 5 * time.Second
+)
+
+func TestClusterapidns(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cluster API DNS Suite")
+}
+
+func kubectlWithConfig(kubeConfigPath string, args ...string) ([]byte, error) {
+	if len(kubeConfigPath) == 0 {
+		return nil, errors.New("kubeconfig path cannot be empty")
+	}
+	argsWithKubeConfig := append([]string{"--kubeconfig", kubeConfigPath}, args...)
+
+	cmd := exec.Command("kubectl", argsWithKubeConfig...)
+	cmd.Stderr = GinkgoWriter
+
+	fmt.Fprintf(GinkgoWriter, " + kubectl %s\n", strings.Join(args, " "))
+	output, err := cmd.Output()
+	return output, err
+}
+
+var clusterOneKubeConfig = os.Getenv("CLUSTER_ONE_KUBECONFIG")
+var clusterTwoKubeConfig = os.Getenv("CLUSTER_TWO_KUBECONFIG")
+
+var _ = BeforeSuite(func() {
+	clusterOneKubeConfig := os.Getenv("CLUSTER_ONE_KUBECONFIG")
+	clusterTwoKubeConfig := os.Getenv("CLUSTER_TWO_KUBECONFIG")
+
+	if len(clusterOneKubeConfig) == 0 {
+		Fail("CLUSTER_ONE_KUBECONFIG not set")
+	}
+	if len(clusterTwoKubeConfig) == 0 {
+		Fail("CLUSTER_TWO_KUBECONFIG not set")
+	}
+})

--- a/test/clusterapidns/endpoint_slice_dns_test.go
+++ b/test/clusterapidns/endpoint_slice_dns_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package connectivity_test
+
+import (
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EndpointSlice DNS", func() {
+	AfterEach(func() {
+		kubectlWithConfig(clusterOneKubeConfig,
+			"delete", "-f", filepath.Join("fixtures", "gateway-endpoint-slice.yaml"))
+	})
+
+	It("journeys", func() {
+		By("create an EndpointSlice with an annotation for the wildcard DNS name")
+		_, err := kubectlWithConfig(clusterOneKubeConfig,
+			"apply", "-f", filepath.Join("fixtures", "gateway-endpoint-slice.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("validating that the wildcard DNS name resolves")
+		Eventually(func() string {
+			output, _ := kubectlWithConfig(clusterOneKubeConfig,
+				"run", "host-test", "-i", "--rm", "--image=curlimages/curl", "--restart=Never", "--command", "--",
+				"nslookup", "bar.gateway.strawberry.foo-ns.clusters.xcc.test")
+			return string(output)
+		}, kubectlTimeout, kubectlInterval).Should(And(ContainSubstring("10.4.5.6"), ContainSubstring("10.4.5.7")))
+
+		By("deleting the EndpointSlice")
+		_, err = kubectlWithConfig(clusterOneKubeConfig,
+			"delete", "-f", filepath.Join("fixtures", "gateway-endpoint-slice.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("validating that the wildcard DNS name no longer resolves")
+		Eventually(func() string {
+			output, _ := kubectlWithConfig(clusterOneKubeConfig,
+				"run", "host-test", "-i", "--rm", "--image=curlimages/curl", "--restart=Never", "--command", "--",
+				"nslookup", "bar.gateway.strawberry.foo-ns.clusters.xcc.test")
+			return string(output)
+		}, kubectlTimeout, kubectlInterval).Should(ContainSubstring("server can't find bar.gateway.strawberry.foo-ns.clusters.xcc.test: NXDOMAIN"))
+	})
+})

--- a/test/clusterapidns/fixtures/gateway-endpoint-slice.yaml
+++ b/test/clusterapidns/fixtures/gateway-endpoint-slice.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: discovery.k8s.io/v1beta1
+kind: EndpointSlice
+metadata:
+  name: foo-strawberry-gateway
+  annotations:
+    connectivity.tanzu.vmware.com/dns-hostname: "*.gateway.strawberry.foo-ns.clusters.xcc.test"
+addressType: IPv4
+endpoints:
+- addresses:
+  - "10.4.5.6"
+  - "10.4.5.7"


### PR DESCRIPTION
<!-- Thanks for contributing to Cross-cluster Connectivity! -->

<!--
Before submitting a pull request, make sure you read about our Contribution
Workflow here: https://github.com/vmware-tanzu/cross-cluster-connectivity/blob/main/CONTRIBUTING.md#contributor-workflow
-->

## Description
- Adds a new controller to connectivity-dns to watch for EndpointSlices
- Updates DNS to support returning multiple A record sets for a DNS query
- Updates DNS to support wildcard DNS records and lookups that resolve to those wildcard DNS records
- Adds new e2e test suite for Cluster API DNS

## Related Issues
Fixes #37 
<!--
All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request
description. Cross-cluster Connectivity operates according to the talk, then
code rule.  If you plan to submit a pull request for anything more than a typo
or obvious bug fix, first you should raise an issue to discuss your proposal,
before submitting any code.
-->
