### PR TITLE
Filter out clusters without capi-dns namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,30 +26,53 @@ make test-unit
 
 ## Building
 
-When you want to build new images of the components to deploy to a Kubernetes
-cluster, you can run:
+When you want to build new images of the components, with local changes, to
+deploy to a Kubernetes cluster, you can run:
 
 ```
 make build-images
 ```
 
-This will take any local changes and build new docker images. These images can
-then be deployed into a Kind cluster by running:
+These images can then be deployed into a set of
+[Kind](https://kind.sigs.k8s.io/) clusters by running:
 
 ```
 make e2e-up
 ```
 
+At the end of this you will have a local end-to-end development environment.
+There will be a `management` cluster with [Cluster
+API](https://cluster-api.sigs.k8s.io/) deployed on it and two workload clusters
+called `cluster-a` and `cluster-b`.
+
 ### Running the end-to-end tests
 
 These tests verify the end-to-end functionality of the Cross-cluster
-Connectivity components. The test creates an example exported service on the
-shared-services cluster and tests connectivity to it from the workload cluster.
+Connectivity components. The test creates an example exported service on
+`cluster-a` and tests connectivity to it from `cluster-b`.
 
-With the clusters created by the instructions above, run the following command:
+With the clusters created by the `e2e-up` above, run the following command:
 
 ```
-make test-connectivity
+make test-cluster-api-dns
+```
+
+### Connecting to the clusters
+
+After running `e2e-up`, there will be three kubeconfig files created in the repo
+root: `management.kubeconfig`, `cluster-a.kubeconfig`, `cluster-b.kubeconfig`.
+For example, to get the pods on `cluster-a` you can run:
+
+```
+kubectl --kubeconfig ./cluster-a.kubeconfig get pods -A
+```
+
+### Tearing down end-to-end development environment
+
+Run the following to tear down the Kind clusters created by `e2e-up`:
+
+```
+make e2e-down
 ```
 
 ### Add license to source files

--- a/pkg/controllers/gatewaydns/endpoint_slice_reconciler.go
+++ b/pkg/controllers/gatewaydns/endpoint_slice_reconciler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	discoveryv1beta1 "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -39,6 +40,18 @@ func (e *EndpointSliceReconciler) ConvergeEndpointSlicesToClusters(ctx context.C
 			log.Error(err, "Failed to get Cluster client")
 			errors = append(errors, err)
 			continue
+		}
+
+		var namespace corev1.Namespace
+		err = clusterClient.Get(ctx, client.ObjectKey{Name: e.Namespace}, &namespace)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			} else {
+				log.Error(err, "Failed to get namespace")
+				errors = append(errors, err)
+				continue
+			}
 		}
 
 		err = e.convergeCluster(ctx, log, gatewayDNSNamespacedName, clusterClient, desiredEndpointSlices)


### PR DESCRIPTION
<!-- Thanks for contributing to Cross-cluster Connectivity! -->

<!--
Before submitting a pull request, make sure you read about our Contribution
Workflow here: https://github.com/vmware-tanzu/cross-cluster-connectivity/blob/main/CONTRIBUTING.md#contributor-workflow
-->

## Description
<!-- A clear and concise description of what the PR is adding or changing. -->
Filter out unnecessary error logging. Clusters without the "capi-dns" namespace aren't necessarily a problem for logging: it just means that the cluster is not using cross-cluster-connectivity.

## Related Issues

<!--
All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request
description. Cross-cluster Connectivity operates according to the talk, then
code rule.  If you plan to submit a pull request for anything more than a typo
or obvious bug fix, first you should raise an issue to discuss your proposal,
before submitting any code.
-->
Fixes #63