### PR TITLE
Add dns-config-patcher to automate setting up kube-system Corefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ IMAGE_TAG ?= dev
 
 DNS_SERVER_IMAGE := $(IMAGE_REGISTRY)/dns-server:$(IMAGE_TAG)
 CAPI_DNS_CONTROLLER_IMAGE := $(IMAGE_REGISTRY)/capi-dns-controller:$(IMAGE_TAG)
+DNS_CONFIG_PATCHER_IMAGE := $(IMAGE_REGISTRY)/dns-config-patcher:$(IMAGE_TAG)
 
 CLUSTER_A := "cluster-a"
 CLUSTER_B := "cluster-b"
@@ -43,18 +44,28 @@ test-cluster-api-dns:
 	ginkgo -v $(PWD)/test/clusterapidns
 
 .PHONY: build-images
-build-images: build-dns-server build-capi-dns-controller
+build-images: build-dns-server build-capi-dns-controller build-dns-config-patcher
 
 .PHONY: build-dns-server
 build-dns-server:
 	docker build -f cmd/dns-server/Dockerfile -t $(DNS_SERVER_IMAGE) .
+
+.PHONY: build-dns-config-patcher
+build-dns-config-patcher:
+	docker build -f cmd/dns-config-patcher/Dockerfile -t $(DNS_CONFIG_PATCHER_IMAGE) .
 
 .PHONY: build-capi-dns-controller
 build-capi-dns-controller:
 	docker build -f cmd/capi-dns-controller/Dockerfile -t $(CAPI_DNS_CONTROLLER_IMAGE) .
 
 .PHONY: e2e-load-images
-e2e-load-images: e2e-load-dns-server-image e2e-load-capi-dns-controller-image
+e2e-load-images: e2e-load-dns-server-image e2e-load-capi-dns-controller-image e2e-load-dns-config-patcher-image
+
+.PHONY: e2e-load-dns-config-patcher-image
+e2e-load-dns-config-patcher-image:
+	kind load docker-image $(DNS_CONFIG_PATCHER_IMAGE) --name $(CLUSTER_A)
+	kind load docker-image $(DNS_CONFIG_PATCHER_IMAGE) --name $(CLUSTER_B)
+	#TODO: re-run the job
 
 .PHONY: e2e-load-dns-server-image
 e2e-load-dns-server-image:

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ e2e-load-images: e2e-load-dns-server-image e2e-load-capi-dns-controller-image e2
 e2e-load-dns-config-patcher-image:
 	kind load docker-image $(DNS_CONFIG_PATCHER_IMAGE) --name $(CLUSTER_A)
 	kind load docker-image $(DNS_CONFIG_PATCHER_IMAGE) --name $(CLUSTER_B)
-	#TODO: re-run the job
 
 .PHONY: e2e-load-dns-server-image
 e2e-load-dns-server-image:

--- a/cmd/dns-config-patcher/Dockerfile
+++ b/cmd/dns-config-patcher/Dockerfile
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM golang AS build
+WORKDIR /build
+
+COPY go.mod go.sum /build/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /bin/dns-config-patcher ./cmd/dns-config-patcher/
+
+FROM scratch AS final
+COPY --from=build /bin/dns-config-patcher /bin/dns-config-patcher
+ENTRYPOINT ["/bin/dns-config-patcher"]

--- a/cmd/dns-config-patcher/main.go
+++ b/cmd/dns-config-patcher/main.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/vmware-tanzu/cross-cluster-connectivity/pkg/dnsconfig"
+)
+
+var (
+	scheme = runtime.NewScheme()
+	log    = ctrl.Log.WithName("dns-config-patcher")
+)
+
+func init() {
+	_ = clientgoscheme.AddToScheme(scheme)
+}
+
+func getEnvVarOrDie(name string, description string) string {
+	envVar, ok := os.LookupEnv(name)
+	if !ok {
+		log.Error(fmt.Errorf("%s environment variable unset. %s", name, description), fmt.Sprintf("unable to get %s environment variable", name))
+		os.Exit(1)
+	}
+	return envVar
+}
+
+func main() {
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	dnsServiceNamespace := getEnvVarOrDie(
+		"DNS_SERVICE_NAMESPACE",
+		"Must be set to the namespace of the DNS service that will handle DNS lookups for the provided DOMAIN_SUFFIX.",
+	)
+
+	dnsServiceName := getEnvVarOrDie(
+		"DNS_SERVICE_NAME",
+		"Must be set to the name of the DNS service that will handle DNS lookups for the provided DOMAIN_SUFFIX.",
+	)
+
+	corefileConfigMapNamespace := getEnvVarOrDie(
+		"COREFILE_CONFIGMAP_NAMESPACE",
+		"Must be set to the namespace of the ConfigMap containing the Corefile to be patched.",
+	)
+
+	corefileConfigMapName := getEnvVarOrDie(
+		"COREFILE_CONFIGMAP_NAME",
+		"Must be set to the name of the ConfigMap containing the Corefile to be patched.",
+	)
+
+	domainSuffix := getEnvVarOrDie(
+		"DOMAIN_SUFFIX",
+		"Must be set to the domain suffix of the zone that is handled by another DNS service.",
+	)
+
+	client, err := client.New(ctrl.GetConfigOrDie(), client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		log.Error(err, "unable to get client")
+		os.Exit(1)
+	}
+
+	dnsServiceWatcher := dnsconfig.DNSServiceWatcher{
+		Client:      client,
+		Namespace:   dnsServiceNamespace,
+		ServiceName: dnsServiceName,
+
+		PollingInterval: 500 * time.Millisecond,
+	}
+
+	dnsServiceWatcherCtx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	dnsServiceClusterIP, err := dnsServiceWatcher.GetDNSServiceClusterIP(dnsServiceWatcherCtx)
+	if err != nil {
+		log.Error(err, "unable to get DNS service ClusterIP")
+		os.Exit(1)
+	}
+
+	patcher := dnsconfig.CorefilePatcher{
+		Client:       client,
+		Log:          log.WithName("CorefilePatcher"),
+		DomainSuffix: domainSuffix,
+
+		Namespace:     corefileConfigMapNamespace,
+		ConfigMapName: corefileConfigMapName,
+	}
+
+	if err = patcher.AppendStubDomainBlock(dnsServiceClusterIP); err != nil {
+		log.Error(err, "unable to append stub domain block")
+		os.Exit(1)
+	}
+
+	log.Info("successfully patched Corefile")
+}

--- a/manifests/dns-config-patcher/deployment.yaml
+++ b/manifests/dns-config-patcher/deployment.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-dns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dns-config-patcher
+  namespace: capi-dns
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dns-config-patcher
+  namespace: capi-dns
+spec:
+  backoffLimit: 10
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      labels:
+        app: dns-config-patcher
+    spec:
+      serviceAccountName: dns-config-patcher
+      restartPolicy: OnFailure
+      containers:
+      - name: dns-config-patcher
+        image: ghcr.io/vmware-tanzu/cross-cluster-connectivity/dns-config-patcher:dev
+        env:
+        - name: "DNS_SERVICE_NAMESPACE"
+          value: "capi-dns"
+        - name: "DNS_SERVICE_NAME"
+          value: "dns-server"
+        - name: "COREFILE_CONFIGMAP_NAMESPACE"
+          value: "kube-system"
+        - name: "COREFILE_CONFIGMAP_NAME"
+          value: "coredns"
+        - name: "DOMAIN_SUFFIX"
+          value: "xcc.test"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: dns-config-patcher
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system-corefile-updater
+subjects:
+- kind: ServiceAccount
+  name: dns-config-patcher
+  namespace: capi-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: dns-config-patcher
+  namespace: capi-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-dns-service-watcher
+subjects:
+- kind: ServiceAccount
+  name: dns-config-patcher
+  namespace: capi-dns
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: system-corefile-updater
+  namespace: kube-system
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: capi-dns-service-watcher
+  namespace: capi-dns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs:
+  - get

--- a/pkg/dnsconfig/corefile_patcher.go
+++ b/pkg/dnsconfig/corefile_patcher.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsconfig
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CorefilePatcher struct {
+	Client       client.Client
+	Log          logr.Logger
+	DomainSuffix string
+
+	Namespace     string
+	ConfigMapName string
+}
+
+const sectionBegin string = "### BEGIN CROSS CLUSTER CONNECTIVITY"
+const sectionEnd string = "### END CROSS CLUSTER CONNECTIVITY"
+
+const xccForwardBlockTemplate string = `%s
+%s {
+    forward . %s
+    reload
+}
+%s`
+
+var serverBlockRegexp = regexp.MustCompile(`(?s)\s` + sectionBegin + ".*" + sectionEnd)
+
+func (c *CorefilePatcher) AppendStubDomainBlock(forwardingIP string) error {
+	var configMap corev1.ConfigMap
+	err := c.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: c.Namespace,
+		Name:      c.ConfigMapName,
+	}, &configMap)
+	if err != nil {
+		return err
+	}
+
+	xccBlock := fmt.Sprintf(xccForwardBlockTemplate,
+		sectionBegin,
+		c.DomainSuffix,
+		forwardingIP,
+		sectionEnd,
+	)
+
+	corefile := configMap.Data["Corefile"]
+
+	if strings.Contains(corefile, xccBlock) {
+		c.Log.Info("up to date, skipping modification", "ConfigMap", fmt.Sprintf("%s/%s", c.Namespace, c.ConfigMapName))
+		return nil
+	}
+
+	corefile = stripXCCBlock(corefile)
+
+	configMap.Data["Corefile"] = fmt.Sprintf("%s\n%s\n", corefile, xccBlock)
+	c.Log.Info("updating Corefile", "ConfigMap", fmt.Sprintf("%s/%s", c.Namespace, c.ConfigMapName))
+
+	return c.Client.Update(context.Background(), &configMap)
+}
+
+func stripXCCBlock(corefile string) string {
+	return strings.TrimSpace(serverBlockRegexp.ReplaceAllString(corefile, ""))
+}

--- a/pkg/dnsconfig/corefile_patcher_test.go
+++ b/pkg/dnsconfig/corefile_patcher_test.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsconfig_test
+
+import (
+	"context"
+	"strings"
+
+	"github.com/vmware-tanzu/cross-cluster-connectivity/pkg/dnsconfig"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CorefilePatcher", func() {
+	var (
+		scheme *runtime.Scheme
+
+		kubeClient client.Client
+
+		patcher          *dnsconfig.CorefilePatcher
+		corednsConfigMap corev1.ConfigMap
+
+		updatedCorednsConfigMap corev1.ConfigMap
+
+		forwardingIP string
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		_ = clientgoscheme.AddToScheme(scheme)
+
+		kubeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		ctrl.SetLogger(zap.New(
+			zap.UseDevMode(true),
+			zap.WriteTo(GinkgoWriter),
+		))
+
+		log := ctrl.Log.WithName("dnsconfig").WithName("CorefilePatcher")
+
+		patcher = &dnsconfig.CorefilePatcher{
+			Client:        kubeClient,
+			Log:           log,
+			DomainSuffix:  "xcc.test",
+			Namespace:     "kube-system",
+			ConfigMapName: "coredns",
+		}
+
+		corednsConfigMap = corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "coredns",
+				Namespace: "kube-system",
+			},
+			Data: map[string]string{
+				"Corefile": strings.Join([]string{
+					".:53 {",
+					"    original_zone_content",
+					"}",
+				}, "\n"),
+			},
+		}
+
+		forwardingIP = "1.2.3.4"
+	})
+
+	It("appends a server block for the provided domain suffix to forward to the dns server service cluster ip", func() {
+		err := kubeClient.Create(context.Background(), &corednsConfigMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = patcher.AppendStubDomainBlock(forwardingIP)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = kubeClient.Get(context.Background(), client.ObjectKey{
+			Name:      "coredns",
+			Namespace: "kube-system",
+		}, &updatedCorednsConfigMap)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updatedCorednsConfigMap.Data["Corefile"]).To(Equal(strings.Join([]string{
+			".:53 {",
+			"    original_zone_content",
+			"}",
+			"### BEGIN CROSS CLUSTER CONNECTIVITY",
+			"xcc.test {",
+			"    forward . 1.2.3.4",
+			"    reload",
+			"}",
+			"### END CROSS CLUSTER CONNECTIVITY",
+			"",
+		}, "\n")))
+	})
+
+	Context("when the system corefile configmap has already been updated", func() {
+		var originalCorefile string
+		BeforeEach(func() {
+			originalCorefile = strings.Join([]string{
+				".:53 {",
+				"    original_zone_content",
+				"}",
+				"### BEGIN CROSS CLUSTER CONNECTIVITY",
+				"xcc.test {",
+				"    forward . 1.2.3.4",
+				"    reload",
+				"}",
+				"### END CROSS CLUSTER CONNECTIVITY",
+				"",
+			}, "\n")
+
+			corednsConfigMap.Data["Corefile"] = originalCorefile
+			err := kubeClient.Create(context.Background(), &corednsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not append a second server block", func() {
+			err := patcher.AppendStubDomainBlock(forwardingIP)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = kubeClient.Get(context.Background(), client.ObjectKey{
+				Name:      "coredns",
+				Namespace: "kube-system",
+			}, &updatedCorednsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updatedCorednsConfigMap.Data["Corefile"]).To(Equal(originalCorefile))
+		})
+	})
+
+	Context("when the system corefile configmap has a different capi-dns domain", func() {
+		BeforeEach(func() {
+			corednsConfigMap.Data["Corefile"] = strings.Join([]string{
+				".:53 {",
+				"    original_zone_content",
+				"}",
+				"### BEGIN CROSS CLUSTER CONNECTIVITY",
+				"xcc-different.test {",
+				"    forward . 1.2.3.4",
+				"    reload",
+				"}",
+				"### END CROSS CLUSTER CONNECTIVITY",
+				"",
+				"other-zone.foobar {",
+				"    forward . 1.2.3.5",
+				"    reload",
+				"}",
+			}, "\n")
+			err := kubeClient.Create(context.Background(), &corednsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("updates the configmap", func() {
+			err := patcher.AppendStubDomainBlock(forwardingIP)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = kubeClient.Get(context.Background(), client.ObjectKey{
+				Name:      "coredns",
+				Namespace: "kube-system",
+			}, &updatedCorednsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updatedCorednsConfigMap.Data["Corefile"]).To(Equal(strings.Join([]string{
+				".:53 {",
+				"    original_zone_content",
+				"}",
+				"",
+				"other-zone.foobar {",
+				"    forward . 1.2.3.5",
+				"    reload",
+				"}",
+				"### BEGIN CROSS CLUSTER CONNECTIVITY",
+				"xcc.test {",
+				"    forward . 1.2.3.4",
+				"    reload",
+				"}",
+				"### END CROSS CLUSTER CONNECTIVITY",
+				"",
+			}, "\n")))
+		})
+	})
+
+	Context("when the system corefile configmap has a different capi-dns IP", func() {
+		BeforeEach(func() {
+			corednsConfigMap.Data["Corefile"] = strings.Join([]string{
+				".:53 {",
+				"    original_zone_content",
+				"}",
+				"",
+				"### BEGIN CROSS CLUSTER CONNECTIVITY",
+				"xcc.test {",
+				"    forward . 42.42.42.42",
+				"    reload",
+				"}",
+				"### END CROSS CLUSTER CONNECTIVITY",
+				"",
+			}, "\n")
+
+			err := kubeClient.Create(context.Background(), &corednsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("updates the configmap", func() {
+			err := patcher.AppendStubDomainBlock(forwardingIP)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = kubeClient.Get(context.Background(), client.ObjectKey{
+				Name:      "coredns",
+				Namespace: "kube-system",
+			}, &updatedCorednsConfigMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(updatedCorednsConfigMap.Data["Corefile"]).To(Equal(strings.Join([]string{
+				".:53 {",
+				"    original_zone_content",
+				"}",
+				"### BEGIN CROSS CLUSTER CONNECTIVITY",
+				"xcc.test {",
+				"    forward . 1.2.3.4",
+				"    reload",
+				"}",
+				"### END CROSS CLUSTER CONNECTIVITY",
+				"",
+			}, "\n")))
+		})
+	})
+})

--- a/pkg/dnsconfig/dns_service_watcher.go
+++ b/pkg/dnsconfig/dns_service_watcher.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsconfig
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DNSServiceWatcher struct {
+	Client client.Client
+
+	Namespace   string
+	ServiceName string
+
+	PollingInterval time.Duration
+}
+
+func (d *DNSServiceWatcher) GetDNSServiceClusterIP(ctx context.Context) (string, error) {
+	for {
+		var dnsService corev1.Service
+		err := d.Client.Get(ctx, client.ObjectKey{
+			Namespace: d.Namespace,
+			Name:      d.ServiceName,
+		}, &dnsService)
+
+		if err == nil && dnsService.Spec.ClusterIP != "" {
+			return dnsService.Spec.ClusterIP, nil
+		}
+		var helpfulError error
+		if err != nil {
+			helpfulError = err
+		} else if dnsService.Spec.ClusterIP == "" {
+			helpfulError = fmt.Errorf(`service "%s/%s" does not have a ClusterIP`, d.Namespace, d.ServiceName)
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf(`Timed out obtaining ClusterIP from service "%s/%s": %s`, d.Namespace, d.ServiceName, helpfulError)
+		case <-time.After(d.PollingInterval):
+		}
+	}
+}

--- a/pkg/dnsconfig/dns_service_watcher_test.go
+++ b/pkg/dnsconfig/dns_service_watcher_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsconfig_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/vmware-tanzu/cross-cluster-connectivity/pkg/dnsconfig"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DNSServiceWatcher", func() {
+	var (
+		scheme              *runtime.Scheme
+		kubeClient          client.Client
+		dnsServiceWatcher   *dnsconfig.DNSServiceWatcher
+		dnsServiceClusterIP string
+
+		ctx       context.Context
+		ctxCancel func()
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		_ = clientgoscheme.AddToScheme(scheme)
+
+		kubeClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		ctrl.SetLogger(zap.New(
+			zap.UseDevMode(true),
+			zap.WriteTo(GinkgoWriter),
+		))
+
+		dnsServiceWatcher = &dnsconfig.DNSServiceWatcher{
+			Client:      kubeClient,
+			Namespace:   "capi-dns",
+			ServiceName: "dns-server",
+
+			PollingInterval: 2 * time.Millisecond,
+		}
+
+		dnsServiceClusterIP = "1.2.3.4"
+		ctx, ctxCancel = context.WithTimeout(context.Background(), 20*time.Millisecond)
+	})
+
+	It("returns the ClusterIP for the DNS service", func() {
+		startupDNSService(kubeClient, dnsServiceClusterIP)
+
+		clusterIP, err := dnsServiceWatcher.GetDNSServiceClusterIP(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(clusterIP).To(Equal(dnsServiceClusterIP))
+	})
+
+	Context("when the CAPI DNS service is not found", func() {
+		It("returns an error", func() {
+			clusterIP, err := dnsServiceWatcher.GetDNSServiceClusterIP(ctx)
+			Expect(err).To(MatchError(`Timed out obtaining ClusterIP from service "capi-dns/dns-server": services "dns-server" not found`))
+			Expect(clusterIP).To(BeEmpty())
+		})
+	})
+
+	Context("when the CAPI DNS service does not acquire a ClusterIP before the context is done", func() {
+		It("does not modify the system Corefile", func() {
+			startupDNSService(kubeClient, dnsServiceClusterIP)
+
+			ctxCancel()
+
+			clusterIP, err := dnsServiceWatcher.GetDNSServiceClusterIP(ctx)
+			Expect(err).To(MatchError(`Timed out obtaining ClusterIP from service "capi-dns/dns-server": service "capi-dns/dns-server" does not have a ClusterIP`))
+			Expect(clusterIP).To(BeEmpty())
+		})
+	})
+})
+
+func startupDNSService(kubeClient client.Client, desiredClusterIP string) {
+	dnsServerService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dns-server",
+			Namespace: "capi-dns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "",
+		},
+	}
+	err := kubeClient.Create(context.Background(), &dnsServerService)
+	Expect(err).NotTo(HaveOccurred())
+
+	time.AfterFunc(10*time.Millisecond, func() {
+		dnsServerService.Spec.ClusterIP = desiredClusterIP
+
+		err = kubeClient.Update(context.Background(), &dnsServerService)
+		Expect(err).NotTo(HaveOccurred())
+	})
+}

--- a/pkg/dnsconfig/systemdnsconfig_suite_test.go
+++ b/pkg/dnsconfig/systemdnsconfig_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dnsconfig_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDNSConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DNS Config Suite")
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Cross-cluster Connectivity! -->

<!--
Before submitting a pull request, make sure you read about our Contribution
Workflow here: https://github.com/vmware-tanzu/cross-cluster-connectivity/blob/main/CONTRIBUTING.md#contributor-workflow
-->

## Description
This PR adds a new Kubernetes Job called "dns-config-patcher" that automatically checks for the capi-dns/dns-server Service and uses its ClusterIP to set up a stubdomain for "xcc.test" in the kube-system coredns ConfigMap.
<!-- A clear and concise description of what the PR is adding or changing. -->

## Related Issues
Fixes #67
<!--
All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request
description. Cross-cluster Connectivity operates according to the talk, then
code rule.  If you plan to submit a pull request for anything more than a typo
or obvious bug fix, first you should raise an issue to discuss your proposal,
before submitting any code.
-->
