### PR TITLE
Merge EndpointSlices with the same dns annotation

### DIFF
--- a/pkg/controllers/endpointslicedns/cache.go
+++ b/pkg/controllers/endpointslicedns/cache.go
@@ -89,11 +89,15 @@ func (d *DNSCache) DeleteByResourceKey(resourceKey string) {
 	if d.entries == nil || d.resourceKeyToFQDN == nil {
 		return
 	}
-	if fqdnToDelete, ok := d.resourceKeyToFQDN[resourceKey]; ok {
-		for i, entry := range d.entries[fqdnToDelete] {
+	if fqdnToUpdate, ok := d.resourceKeyToFQDN[resourceKey]; ok {
+		for i, entry := range d.entries[fqdnToUpdate] {
 			if entry.ResourceKey == resourceKey {
-				d.entries[fqdnToDelete] = append(d.entries[fqdnToDelete][:i], d.entries[fqdnToDelete][i+1:]...)
+				d.entries[fqdnToUpdate] = append(d.entries[fqdnToUpdate][:i], d.entries[fqdnToUpdate][i+1:]...)
 				break
+			}
+
+			if len(d.entries[fqdnToUpdate]) == 0 {
+				delete(d.entries, fqdnToUpdate)
 			}
 		}
 		delete(d.resourceKeyToFQDN, resourceKey)

--- a/pkg/coredns/plugins/crosscluster/crosscluster.go
+++ b/pkg/coredns/plugins/crosscluster/crosscluster.go
@@ -34,17 +34,19 @@ var errNameNotFound = errors.New("name not found")
 func (c *CrossCluster) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) ([]msg.Service, error) {
 	fqdn := strings.ToLower(state.QName())
 
-	cacheEntry := c.RecordsCache.Lookup(fqdn)
-	if cacheEntry == nil {
+	cacheEntries := c.RecordsCache.Lookup(fqdn)
+	if len(cacheEntries) == 0 {
 		return nil, errNameNotFound
 	}
 
 	services := []msg.Service{}
-	for _, ip := range cacheEntry.IPs {
-		services = append(services, msg.Service{
-			Host: ip.String(),
-			TTL:  30,
-		})
+	for _, cacheEntry := range cacheEntries {
+		for _, ip := range cacheEntry.IPs {
+			services = append(services, msg.Service{
+				Host: ip.String(),
+				TTL:  30,
+			})
+		}
 	}
 
 	return services, nil


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is adding or changing. -->
This merges EndpointSlices with the same dns annotation for the dns server.

Some notes about the implementation:
* The dns cache can now support upserting with the same fqdn, but from different resources. If an upsert occurs with the same resource key then it is considered an update.
* Deleting using a resource key will not delete the entire fqdn and will only delete the cache entry from the fqdn.
* Lookup now returns a slice of cache entries instead of a single entry.

## Related Issues

Fixes #46 
