### PR TITLE
Add support for FQDN EndpointSlice

### DIFF
--- a/pkg/controllers/endpointslicedns/cache.go
+++ b/pkg/controllers/endpointslicedns/cache.go
@@ -52,6 +52,12 @@ func (d *DNSCache) Upsert(entry DNSCacheEntry) {
 		}
 	}
 
+	for i, address := range entry.Addresses {
+		if net.ParseIP(address) == nil {
+			entry.Addresses[i] = dns.CanonicalName(address)
+		}
+	}
+
 	updated := false
 	for i, e := range d.entries[fqdn] {
 		if e.ResourceKey == entry.ResourceKey {

--- a/pkg/controllers/endpointslicedns/cache.go
+++ b/pkg/controllers/endpointslicedns/cache.go
@@ -5,7 +5,6 @@ package endpointslicedns
 
 import (
 	"fmt"
-	"net"
 	"strings"
 	"sync"
 
@@ -16,7 +15,7 @@ import (
 type DNSCacheEntry struct {
 	ResourceKey string
 	FQDN        string
-	IPs         []net.IP
+	Addresses   []string
 }
 
 // DNSCache maps Domain Name -> DNSCacheEntry

--- a/pkg/controllers/endpointslicedns/cache_test.go
+++ b/pkg/controllers/endpointslicedns/cache_test.go
@@ -4,8 +4,6 @@
 package endpointslicedns_test
 
 import (
-	"net"
-
 	"github.com/vmware-tanzu/cross-cluster-connectivity/pkg/controllers/endpointslicedns"
 
 	. "github.com/onsi/ginkgo"
@@ -22,7 +20,7 @@ var _ = Describe("DNSCache", func() {
 			dnsCacheEntry := endpointslicedns.DNSCacheEntry{
 				ResourceKey: "12345-abc",
 				FQDN:        "a.b.c",
-				IPs:         []net.IP{net.ParseIP("1.2.3.4")},
+				Addresses:   []string{"1.2.3.4"},
 			}
 			cache.Upsert(dnsCacheEntry)
 
@@ -41,7 +39,7 @@ var _ = Describe("DNSCache", func() {
 				someEntry = endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-some",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("1.2.3.4")},
+					Addresses:   []string{"1.2.3.4"},
 				}
 				cache.Upsert(someEntry)
 			})
@@ -53,7 +51,7 @@ var _ = Describe("DNSCache", func() {
 				anotherEntry := endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-another",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("4.5.6.7")},
+					Addresses:   []string{"4.5.6.7"},
 				}
 				cache.Upsert(anotherEntry)
 				Expect(cache.Lookup("a.b.c")).To(ConsistOf(someEntry, anotherEntry))
@@ -68,7 +66,7 @@ var _ = Describe("DNSCache", func() {
 				dnsCacheEntry := endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc",
 					FQDN:        "*.b.c",
-					IPs:         []net.IP{net.ParseIP("1.2.3.4")},
+					Addresses:   []string{"1.2.3.4"},
 				}
 				cache.Upsert(dnsCacheEntry)
 
@@ -91,7 +89,7 @@ var _ = Describe("DNSCache", func() {
 				oldEntry = endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("1.2.3.4")},
+					Addresses:   []string{"1.2.3.4"},
 				}
 				cache.Upsert(oldEntry)
 			})
@@ -104,7 +102,7 @@ var _ = Describe("DNSCache", func() {
 				newEntry := endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc",
 					FQDN:        "b.c.d",
-					IPs:         []net.IP{net.ParseIP("4.5.6.7")},
+					Addresses:   []string{"4.5.6.7"},
 				}
 				cache.Upsert(newEntry)
 				Expect(cache.Lookup("a.b.c")).To(BeEmpty())
@@ -127,14 +125,14 @@ var _ = Describe("DNSCache", func() {
 				oldEntry = endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc-old",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("1.2.3.4")},
+					Addresses:   []string{"1.2.3.4"},
 				}
 				cache.Upsert(oldEntry)
 
 				oldEntry2 = endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc-old-2",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("2.3.4.5")},
+					Addresses:   []string{"2.3.4.5"},
 				}
 				cache.Upsert(oldEntry2)
 			})
@@ -173,7 +171,7 @@ var _ = Describe("DNSCache", func() {
 				oldEntry = endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc-old",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("1.2.3.4")},
+					Addresses:   []string{"1.2.3.4"},
 				}
 				cache.Upsert(oldEntry)
 			})
@@ -201,14 +199,14 @@ var _ = Describe("DNSCache", func() {
 				oldEntry = endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc-old",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("1.2.3.4")},
+					Addresses:   []string{"1.2.3.4"},
 				}
 				cache.Upsert(oldEntry)
 
 				anotherEntry = endpointslicedns.DNSCacheEntry{
 					ResourceKey: "12345-abc-another",
 					FQDN:        "a.b.c",
-					IPs:         []net.IP{net.ParseIP("2.3.4.5")},
+					Addresses:   []string{"2.3.4.5"},
 				}
 				cache.Upsert(anotherEntry)
 			})

--- a/pkg/controllers/endpointslicedns/controller.go
+++ b/pkg/controllers/endpointslicedns/controller.go
@@ -78,6 +78,17 @@ func (r *EndpointSliceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	})
 	log.WithValues("dns-hostname", fqdn).Info("Successfully synced")
 
+	if !r.RecordsCache.IsValid(fqdn) {
+		log.Error(
+			fmt.Errorf(`DNS entry for "%s" is in an invalid state.`, fqdn),
+			"If this FQDN is to resolve to a CNAME record, check to ensure any "+
+				" FQDN EndpointSlice associated with this FQDN is the only "+
+				"EndpointSlice annotated with this FQDN. Otherwise, if the FQDN is to "+
+				"resolve to an A record, then ensure there are no FQDN EndpointSlices "+
+				"annotated with this FQDN.",
+		)
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/endpointslicedns/controller.go
+++ b/pkg/controllers/endpointslicedns/controller.go
@@ -5,8 +5,10 @@ package endpointslicedns
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/go-logr/logr"
 	connectivityv1alpha1 "github.com/vmware-tanzu/cross-cluster-connectivity/apis/connectivity/v1alpha1"
@@ -79,14 +81,18 @@ func (r *EndpointSliceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	log.WithValues("dns-hostname", fqdn).Info("Successfully synced")
 
 	if !r.RecordsCache.IsValid(fqdn) {
-		log.Error(
-			fmt.Errorf(`DNS entry for "%s" is in an invalid state.`, fqdn),
-			"If this FQDN is to resolve to a CNAME record, check to ensure any "+
-				" FQDN EndpointSlice associated with this FQDN is the only "+
-				"EndpointSlice annotated with this FQDN. Otherwise, if the FQDN is to "+
-				"resolve to an A record, then ensure there are no FQDN EndpointSlices "+
-				"annotated with this FQDN.",
-		)
+		errLines := []string{
+			fmt.Sprintf(`DNS entry for "%s" is in an invalid state and will`, fqdn),
+			`lead to undefined behavior on DNS lookup.`,
+		}
+		msgLines := []string{
+			"If this FQDN is to resolve to a CNAME record, check to ensure any",
+			"FQDN EndpointSlice associated with this FQDN is the only",
+			"EndpointSlice annotated with this FQDN. Otherwise, if the FQDN is to",
+			"resolve to an A record, then ensure there are no FQDN EndpointSlices",
+			"annotated with this FQDN.",
+		}
+		log.Error(errors.New(strings.Join(errLines, " ")), strings.Join(msgLines, " "))
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/controllers/endpointslicedns/controller_test.go
+++ b/pkg/controllers/endpointslicedns/controller_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Reconcile", func() {
 
 				cacheEntries := dnsCache.Lookup("foo.xcc.test")
 				Expect(cacheEntries).NotTo(BeEmpty())
-				Expect(cacheEntriesToAddresses(cacheEntries)).To(ConsistOf("foo.com"))
+				Expect(cacheEntriesToAddresses(cacheEntries)).To(ConsistOf("foo.com."))
 			})
 
 			When("there are (invalidly) multiple addresses in the EndpointSlice", func() {
@@ -264,7 +264,7 @@ var _ = Describe("Reconcile", func() {
 
 					cacheEntries := dnsCache.Lookup("foo.xcc.test")
 					Expect(cacheEntries).NotTo(BeEmpty())
-					Expect(cacheEntriesToAddresses(cacheEntries)).To(ConsistOf("foo.com", "bar.com", "baz.com"))
+					Expect(cacheEntriesToAddresses(cacheEntries)).To(ConsistOf("foo.com.", "bar.com.", "baz.com."))
 				})
 
 			})

--- a/pkg/coredns/plugins/crosscluster/crosscluster.go
+++ b/pkg/coredns/plugins/crosscluster/crosscluster.go
@@ -41,9 +41,9 @@ func (c *CrossCluster) Services(ctx context.Context, state request.Request, exac
 
 	services := []msg.Service{}
 	for _, cacheEntry := range cacheEntries {
-		for _, ip := range cacheEntry.IPs {
+		for _, address := range cacheEntry.Addresses {
 			services = append(services, msg.Service{
-				Host: ip.String(),
+				Host: address,
 				TTL:  30,
 			})
 		}

--- a/pkg/coredns/plugins/crosscluster/handler.go
+++ b/pkg/coredns/plugins/crosscluster/handler.go
@@ -27,6 +27,8 @@ func (c *CrossCluster) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dn
 		records, err = plugin.SOA(ctx, c, zone, state, opt)
 	case dns.TypeA:
 		records, err = plugin.A(ctx, c, zone, state, nil, opt)
+	case dns.TypeCNAME:
+		records, err = plugin.CNAME(ctx, c, zone, state, opt)
 	default:
 		return plugin.BackendError(ctx, c, zone, dns.RcodeNameError, state, nil, opt)
 	}

--- a/pkg/coredns/plugins/crosscluster/handler_test.go
+++ b/pkg/coredns/plugins/crosscluster/handler_test.go
@@ -62,7 +62,7 @@ var _ = Describe("CrossCluster", func() {
 			dnsCache.Upsert(endpointslicedns.DNSCacheEntry{
 				ResourceKey: "other-namespace/another-service",
 				FQDN:        "another-service.other.domain",
-				Addresses:   []string{"baz.com"},
+				Addresses:   []string{"BAZ.com"},
 			})
 		})
 


### PR DESCRIPTION
## Description
Adds support for FQDN EndpointSlices and adds handling for CNAME DNS queries in the DNS server.

Important caveat: Mixing IPv4 and FQDN EndpointSlices for a single FQDN is undefined behavior. The DNS server will log an error message when it detects this mixing, but will continue to reconcile the EndpointSlices. When querying the FQDN, the user may or may not see the desired DNS response.

## Related Issues

Fixes #96 
