### PR TITLE
Remove needs-triage label from new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: kind/feature, lifecycle/needs-triage
+labels: kind/feature
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description
<!-- A clear and concise description of what the PR is adding or changing. -->
Consider removing the needs-triage label from new issues. We haven't really taken advantage of using the label so it seems unnecessary at this point in time.

## Related Issues

<!--
All PR's should have a `Fixes #NNN` or `Updates #NNN` line in the pull request
description. Cross-cluster Connectivity operates according to the talk, then
code rule.  If you plan to submit a pull request for anything more than a typo
or obvious bug fix, first you should raise an issue to discuss your proposal,
before submitting any code.
-->

n/a
